### PR TITLE
Add ASUS VivoTab Smart

### DIFF
--- a/Mobile_Detect.php
+++ b/Mobile_Detect.php
@@ -82,7 +82,7 @@ class Mobile_Detect {
         // Only the Surface tablets with Windows RT are considered mobile.
         // @ref: http://msdn.microsoft.com/en-us/library/ie/hh920767(v=vs.85).aspx
         'SurfaceTablet'     => 'Windows NT [0-9.]+; ARM;',
-        'AsusTablet'        => 'Transformer|TF101',
+        'AsusTablet'        => 'Transformer|TF101|Touch.*ASU|ASU2JS',
         'BlackBerryTablet'  => 'PlayBook|RIM Tablet',
         'HTCtablet'         => 'HTC Flyer|HTC Jetstream|HTC-P715a|HTC EVO View 4G|PG41200',
         'MotorolaTablet'    => 'xoom|sholest|MZ615|MZ605|MZ505|MZ601|MZ602|MZ603|MZ604|MZ606|MZ607|MZ608|MZ609|MZ615|MZ616|MZ617',


### PR DESCRIPTION
ASUS VivoTab Smart ME400C

The device `UserAgent` is 
Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0; Touch; ASU2JS)
