### PR TITLE
Added a method to retrieve the array of mobile browsers and changed '->userAgents' to '->browsers' for clarity.

### DIFF
--- a/Mobile_Detect.php
+++ b/Mobile_Detect.php
@@ -270,11 +270,11 @@ class Mobile_Detect
     );
 
     /**
-     * List of mobile User Agents.
+     * List of mobile browsers.
      *
      * @var array
      */
-    protected $userAgents = array(
+    protected $browsers = array(
         // @reference: https://developers.google.com/chrome/mobile/docs/user-agent
         'Chrome'          => '\bCrMo\b|CriOS|Android.*Chrome/[.0-9]* (Mobile)?',
         'Dolfin'          => '\bDolfin\b',
@@ -561,7 +561,7 @@ class Mobile_Detect
             $this->phoneDevices,
             $this->tabletDevices,
             $this->operatingSystems,
-            $this->userAgents
+            $this->browsers
         );
 
     }
@@ -579,7 +579,7 @@ class Mobile_Detect
             $this->phoneDevices,
             $this->tabletDevices,
             $this->operatingSystems,
-            $this->userAgents,
+            $this->browsers,
             $this->utilities
         );
 
@@ -789,6 +789,16 @@ class Mobile_Detect
     public function getOperatingSystems()
     {
         return $this->operatingSystems;
+    }
+    
+    /**
+     * Retrieve the list of mobile browsers.
+     * 
+     * @return array The list of mobile browsers.
+     */
+    public function getBrowsers()
+    {
+        return $this->browsers;
     }
 
     /**


### PR DESCRIPTION
Hi,
I needed to get the `->userAgents` array from outside of `Mobile_Detect.php` so I've added a method to retrieve it.

Then however, you end up with:
`$md->getUserAgent();`
`$md->getUserAgents();`
which in my opinion may be confusing.

There are two simple ways to differentiate between the user agent string that was taken from `HTTP_USER_AGENT` and the array of browser names and regex matches:
- either change `userAgent` to `userAgentString`
- or change `userAgents` to `browsers`

I've chosen the second options and here's the commit.
