### PR TITLE
Split iPhone and iPod devices

### DIFF
--- a/Mobile_Detect.php
+++ b/Mobile_Detect.php
@@ -104,7 +104,8 @@ class Mobile_Detect
      * @var array
      */
     protected static $phoneDevices = array(
-        'iPhone'        => '\biPhone.*Mobile|\biPod', // |\biTunes
+        'iPhone'        => '\biPhone.*Mobile', // |\biTunes
+        'iPod'          => '\biPod',
         'BlackBerry'    => 'BlackBerry|\bBB10\b|rim[0-9]+',
         'HTC'           => 'HTC|HTC.*(Sensation|Evo|Vision|Explorer|6800|8100|8900|A7272|S510e|C110e|Legend|Desire|T8282)|APX515CKT|Qtek9090|APA9292KT|HD_mini|Sensation.*Z710e|PG86100|Z715e|Desire.*(A8181|HD)|ADR6200|ADR6400L|ADR6425|001HT|Inspire 4G|Android.*\bEVO\b',
         'Nexus'         => 'Nexus One|Nexus S|Galaxy.*Nexus|Android.*Nexus.*Mobile',


### PR DESCRIPTION
I have a method like this:

```php
    public function getDevice()
    {
        if (is_null($this->_device)) {
            foreach (self::getPhoneDevices() + self::getTabletDevices() as $key => $rule) {
                if ($this->match($rule)) {
                    $this->_device = $key;
                    break;
                }
            }
        }

        return $this->_device;
    }
```

With this simple patch I can correctly detect iPod now.