### PR TITLE
Add hhvm to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 php:
   - "5.2"
+  - "hhvm"
 
 branches:
   only:


### PR DESCRIPTION
Tried this out on Ubuntu x64, tests output looks identical to what is on travis-ci now.

```
$ hhvm ../vendor/bin/phpunit
PHPUnit 3.7.23 by Sebastian Bergmann.

Configuration read from /home/vagrant/Mobile-Detect/tests/phpunit.xml

...............................................I...............  63 / 752 (  8%)
............................................................... 126 / 752 ( 16%)
............................................................... 189 / 752 ( 25%)
............................................................... 252 / 752 ( 33%)
............................................................... 315 / 752 ( 41%)
............................................................... 378 / 752 ( 50%)
............................................................... 441 / 752 ( 58%)
............................................................... 504 / 752 ( 67%)
............................................................... 567 / 752 ( 75%)
............................................................... 630 / 752 ( 83%)
.....................................................IIIIIIIIII 693 / 752 ( 92%)
IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII.......

Time: 2.99 seconds, Memory: 23.73Mb

OK, but incomplete or skipped tests!
Tests: 752, Assertions: 3736, Incomplete: 63.
```
