### PR TITLE
Take out HTTP_X_NOKIA_IPADDRESS

### DIFF
--- a/Mobile_Detect.php
+++ b/Mobile_Detect.php
@@ -119,7 +119,6 @@ class Mobile_Detect
             'HTTP_PROFILE'                 => null,
             // Reported by Opera on Nokia devices (eg. C3).
             'HTTP_X_OPERAMINI_PHONE_UA'    => null,
-            'HTTP_X_NOKIA_IPADDRESS'       => null,
             'HTTP_X_NOKIA_GATEWAY_ID'      => null,
             'HTTP_X_ORANGE_ID'             => null,
             'HTTP_X_VODAFONE_3GPDPCONTEXT' => null,

--- a/tests/BasicsTest.php
+++ b/tests/BasicsTest.php
@@ -280,9 +280,6 @@ class BasicTest extends PHPUnit_Framework_TestCase
                 'HTTP_X_OPERAMINI_PHONE_UA' => ''
             )),
             array(array(
-                'HTTP_X_NOKIA_IPADDRESS' => ''
-            )),
-            array(array(
                 'HTTP_X_NOKIA_GATEWAY_ID' => ''
             )),
             array(array(


### PR DESCRIPTION
Possible code change related to issue #185

This short cut causes some tethered desktop connections to falsely
report as mobile devices. Particularly the EE network in the UK. It's
unfortunate to have to remove it, but a user agent check should cover
devices that this shortcut header anyway.
