### PR TITLE
Memory improvement at the cost of less portability

### DIFF
--- a/Mobile_Detect.php
+++ b/Mobile_Detect.php
@@ -1030,10 +1030,7 @@ class Mobile_Detect
      */
     public function match($regex, $userAgent = null)
     {
-        // Escape the special character which is the delimiter.
-        $regex = str_replace('/', '\/', $regex);
-
-        return (bool) preg_match('/'.$regex.'/is', (!empty($userAgent) ? $userAgent : $this->userAgent));
+        return (bool) preg_match('#'.$regex.'#is', (!empty($userAgent) ? $userAgent : $this->userAgent));
     }
 
     /**
@@ -1104,11 +1101,8 @@ class Mobile_Detect
 
                 $propertyPattern = str_replace('[VER]', self::VER, $propertyMatchString);
 
-                // Escape the special character which is the delimiter.
-                $propertyPattern = str_replace('/', '\/', $propertyPattern);
-
                 // Identify and extract the version.
-                preg_match('/'.$propertyPattern.'/is', $this->userAgent, $match);
+                preg_match('#'.$propertyPattern.'#is', $this->userAgent, $match);
 
                 if (!empty($match[1])) {
                     $version = ( $type == self::VERSION_TYPE_FLOAT ? $this->prepareVersionNo($match[1]) : $match[1] );


### PR DESCRIPTION
You may disagree on this pull request because it removes the regexp delimiter escaping need by using a regexp delimiter (#) that is not used today in user agents or properties. But as a consequence, it is required that no UA or properties using the # sign in the future are added to mobile-detect regexes.

Else use this patch to save cpu time and memory.

Test results on a desktop browser ($md->isMobile() test)

![image](https://cloud.githubusercontent.com/assets/1324566/3894854/ca28c7a4-2248-11e4-819b-237823c26c18.png)
