### PR TITLE
Fix @covers annotation for PHPUnit code coverage

### DIFF
--- a/tests/BasicsTest.php
+++ b/tests/BasicsTest.php
@@ -177,7 +177,8 @@ class BasicTest extends PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider userAgentProvider
-     * @covers Mobile_Detect::setUserAgent, Mobile_Detect::getUserAgent
+     * @covers Mobile_Detect::setUserAgent
+     * @covers Mobile_Detect::getUserAgent
      */
     public function testGetUserAgent($headers, $expectedUserAgent)
     {
@@ -203,7 +204,8 @@ class BasicTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Mobile_Detect::setUserAgent, Mobile_Detect::getUserAgent
+     * @covers Mobile_Detect::setUserAgent
+     * @covers Mobile_Detect::getUserAgent
      */
     public function testSetUserAgent()
     {


### PR DESCRIPTION
Current versions of PHPUnit report `Trying to @cover or @use not existing method "Mobile_Detect::setUserAgent, Mobile_Detect".` when running code coverage.

This fixes that error by separating the `@covers` annotation to multiple lines.
