### PR TITLE
Windows phone 10 devices are out in the wild

### DIFF
--- a/Mobile_Detect.php
+++ b/Mobile_Detect.php
@@ -475,7 +475,8 @@ class Mobile_Detect
         // http://wifeng.cn/?r=blog&a=view&id=106
         // http://nicksnettravels.builttoroam.com/post/2011/01/10/Bogus-Windows-Phone-7-User-Agent-String.aspx
         // http://msdn.microsoft.com/library/ms537503.aspx
-        'WindowsPhoneOS'   => 'Windows Phone 8.1|Windows Phone 8.0|Windows Phone OS|XBLWP7|ZuneWP7|Windows NT 6.[23]; ARM;',
+        // https://msdn.microsoft.com/en-us/library/hh869301(v=vs.85).aspx
+        'WindowsPhoneOS'   => 'Windows Phone 10.0|Windows Phone 8.1|Windows Phone 8.0|Windows Phone OS|XBLWP7|ZuneWP7|Windows NT 6.[23]; ARM;',
         'iOS'               => '\biPhone.*Mobile|\biPod|\biPad',
         // http://en.wikipedia.org/wiki/MeeGo
         // @todo: research MeeGo in UAs


### PR DESCRIPTION
Match Windows Mobile 10 devices to `WindowsPhoneOS`.

Documentation about those devices' user-agent can be found in:
[Internet Explorer -> Compatibility -> Internet Explorer compatibility cookbook -> Browser features and compatibility changes](https://msdn.microsoft.com/en-us/library/hh869301%28v=vs.85%29.aspx?f=255&MSPPError=-2147217396)


An example user-agent is:
`Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; NOKIA; Lumia 635) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Mobile Safari/537.36 Edge/12.10166`