### PR TITLE
Add weChat browser detect

### DIFF
--- a/Mobile_Detect.php
+++ b/Mobile_Detect.php
@@ -528,6 +528,8 @@ class Mobile_Detect
         // @reference: http://en.wikipedia.org/wiki/Minimo
         // http://en.wikipedia.org/wiki/Vision_Mobile_Browser
         'GenericBrowser'  => 'NokiaBrowser|OviBrowser|OneBrowser|TwonkyBeamBrowser|SEMC.*Browser|FlyFlow|Minimo|NetFront|Novarra-Vision|MQQBrowser|MicroMessenger',
+        //weChat detect (weChat is Chinese dominated chat app on mobile which has 600M users/month)
+        'weChat'        => 'MicroMessenger',
     );
 
     /**


### PR DESCRIPTION
## Add feature:
weChat browser detect.

## Reason:
Developer often need to know site is opened in weChat or in browser. If in weChat some operation is not supported by weChat. We have to info user to open in safari or other browser. So we need to know it is opened in weChat or not. 

