### PR TITLE
Updated Acer tablet regex for Acer A3-A20FHD

### DIFF
--- a/Mobile_Detect.php
+++ b/Mobile_Detect.php
@@ -239,7 +239,7 @@ class Mobile_Detect
         // http://us.acer.com/ac/en/US/content/group/tablets
         // http://www.acer.de/ac/de/DE/content/models/tablets/
         // Can conflict with Micromax and Motorola phones codes.
-        'AcerTablet'        => 'Android.*; \b(A100|A101|A110|A200|A210|A211|A500|A501|A510|A511|A700|A701|W500|W500P|W501|W501P|W510|W511|W700|G100|G100W|B1-A71|B1-710|B1-711|A1-810|A1-811|A1-830)\b|W3-810|\bA3-A10\b|\bA3-A11\b',
+        'AcerTablet'        => 'Android.*; \b(A100|A101|A110|A200|A210|A211|A500|A501|A510|A511|A700|A701|W500|W500P|W501|W501P|W510|W511|W700|G100|G100W|B1-A71|B1-710|B1-711|A1-810|A1-811|A1-830)\b|W3-810|\bA3-A10\b|\bA3-A11\b|\bA3-A20',
         // http://eu.computers.toshiba-europe.com/innovation/family/Tablets/1098744/banner_id/tablet_footerlink/
         // http://us.toshiba.com/tablets/tablet-finder
         // http://www.toshiba.co.jp/regza/tablet/


### PR DESCRIPTION
User agent
Mozilla/5.0 (Linux; Android 4.4.2; A3-A20FHD Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.105 Safari/537.36