### PR TITLE
Other Mobile HTTP Headers should be checked if 'HTTP_ACCEPT' doesn't …

### DIFF
--- a/Mobile_Detect.php
+++ b/Mobile_Detect.php
@@ -1030,7 +1030,6 @@ class Mobile_Detect
                         }
                     }
 
-                    return false;
                 } else {
                     return true;
                 }
@@ -1328,7 +1327,7 @@ class Mobile_Detect
         $isMobile = $this->isMobile();
 
         if (
-            // Apple iOS 4-7.0 – Tested on the original iPad (4.3 / 5.0), iPad 2 (4.3 / 5.1 / 6.1), iPad 3 (5.1 / 6.0), iPad Mini (6.1), iPad Retina (7.0), iPhone 3GS (4.3), iPhone 4 (4.3 / 5.1), iPhone 4S (5.1 / 6.0), iPhone 5 (6.0), and iPhone 5S (7.0)
+            // Apple iOS 4-7.0 – Tested on the original iPad (4.3 /checkHttpHeadersForMobile 5.0), iPad 2 (4.3 / 5.1 / 6.1), iPad 3 (5.1 / 6.0), iPad Mini (6.1), iPad Retina (7.0), iPhone 3GS (4.3), iPhone 4 (4.3 / 5.1), iPhone 4S (5.1 / 6.0), iPhone 5 (6.0), and iPhone 5S (7.0)
             $this->is('iOS') && $this->version('iPad', self::VERSION_TYPE_FLOAT) >= 4.3 ||
             $this->is('iOS') && $this->version('iPhone', self::VERSION_TYPE_FLOAT) >= 4.3 ||
             $this->is('iOS') && $this->version('iPod', self::VERSION_TYPE_FLOAT) >= 4.3 ||


### PR DESCRIPTION
…match

To check other Mobile HTTP Headers other than 'HTTP_ACCEPT'. Currently if  'HTTP_ACCEPT' present other Mobile HTTP Headers were not checked even if 'HTTP_ACCEPT' doesn't match with 'matches' array members
