### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=5.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8|5.7"
+        "phpunit/phpunit": "~4.8.35|5.7"
     },
     "autoload": {
         "classmap": ["Mobile_Detect.php"],

--- a/tests/BasicsTest.php
+++ b/tests/BasicsTest.php
@@ -1,9 +1,12 @@
 <?php
+
+use PHPUnit\Framework\TestCase;
+
 /**
  * @license     MIT License https://github.com/serbanghita/Mobile-Detect/blob/master/LICENSE.txt
  * @link        http://mobiledetect.net
  */
-class BasicTest extends PHPUnit_Framework_TestCase
+class BasicTest extends TestCase
 {
     /**
      * @var Mobile_Detect

--- a/tests/UserAgentTest.php
+++ b/tests/UserAgentTest.php
@@ -1,9 +1,12 @@
 <?php
+
+use PHPUnit\Framework\TestCase;
+
 /**
  * @license     MIT License https://github.com/serbanghita/Mobile-Detect/blob/master/LICENSE.txt
  * @link        http://mobiledetect.net
  */
-class UserAgentTest extends PHPUnit_Framework_TestCase
+class UserAgentTest extends TestCase
 {
     protected $detect;
     protected static $ualist = array();

--- a/tests/VendorsTest_tmp.php
+++ b/tests/VendorsTest_tmp.php
@@ -1,9 +1,12 @@
 <?php
+
+use PHPUnit\Framework\TestCase;
+
 /**
  * @license     MIT License https://github.com/serbanghita/Mobile-Detect/blob/master/LICENSE.txt
  * @link        http://mobiledetect.net
  */
-class VendorsTest extends PHPUnit_Framework_TestCase
+class VendorsTest extends TestCase
 {
     protected $detect;
     protected static $items;


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit\Framework\TestCase` while extending our TestCases. This will help us when migrating to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/6.0/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit to version [`4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/4.8/ChangeLog-4.8.md#4835---2017-02-06), that supports this namespace.