### PR TITLE
Detecting Android 8.1 on Pixel 2 as Galapad tablet fixed

### DIFF
--- a/Mobile_Detect.php
+++ b/Mobile_Detect.php
@@ -336,7 +336,7 @@ class Mobile_Detect
         // http://www.danytech.com/category/tablet-pc
         'DanyTechTablet' => 'Genius Tab G3|Genius Tab S2|Genius Tab Q3|Genius Tab G4|Genius Tab Q4|Genius Tab G-II|Genius TAB GII|Genius TAB GIII|Genius Tab S1',
         // http://www.galapad.net/product.html
-        'GalapadTablet'     => 'Android.*\bG1\b',
+        'GalapadTablet'     => 'Android.*\bG1\b(?!\))',
         // http://www.micromaxinfo.com/tablet/funbook
         'MicromaxTablet'    => 'Funbook|Micromax.*\b(P250|P560|P360|P362|P600|P300|P350|P500|P275)\b',
         // http://www.karbonnmobiles.com/products_tablet.php

--- a/tests/providers/vendors/Google.php
+++ b/tests/providers/vendors/Google.php
@@ -18,5 +18,6 @@ return array(
         'Mozilla/5.0 (Linux; Android 7.1; Pixel Build/NDE63H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36'                                               => array('isMobile' => true, 'isTablet' => false),
         'Mozilla/5.0 (Linux; Android 8.1.0; Pixel C Build/OPM1.171019.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/65.0.3325.109 Safari/537.36'                        => array('isMobile' => true, 'isTablet' => true),
         'Mozilla/5.0 (Linux; Android 8.1.0; Pixel C Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Safari/537.36'                                        => array('isMobile' => true, 'isTablet' => true),
+        'Mozilla/5.0 (Linux; Android 8.1.0; Pixel 2 Build/OPM2.171026.006.G1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36'                                        => array('isMobile' => true, 'isTablet' => false),
         ),
 );

--- a/tests/ualist.json
+++ b/tests/ualist.json
@@ -1,2725 +1,113 @@
 {
-    "hash": "84dc88439d9c4e0bf7b3b57557552028ae23a4bf",
+    "hash": "16a211ba26bde900d163f7b624c46967cb9b3d28",
     "user_agents": [
         {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.6; en-us; LG-VS410PP Build\/GRK39F) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "vendor": "Lava",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.6; en-us; Iris 349 Build\/MocorDroid2.3.5) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
             "mobile": true,
             "tablet": false
         },
         {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2; en-us; LG-P509 Build\/FRF91) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1 MMS\/LG-Android-MMS-V1.0\/1.2",
+            "vendor": "Lava",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; iris402+ Build\/iris402+) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
             "mobile": true,
             "tablet": false
         },
         {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2.2; pt-br; LG-P350f Build\/FRG83G) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1 MMS\/LG-Android-MMS-V1.0\/1.2",
+            "vendor": "Lava",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; IRIS402 Build\/LAVAIRIS402) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
             "mobile": true,
             "tablet": false
         },
         {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.3; en-us; LG-P500 Build\/GRI40) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1 MMS\/LG-Android-MMS-V1.0\/1.2",
+            "vendor": "Lava",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; iris405 Build\/LAVAIRIS405) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
             "mobile": true,
             "tablet": false
         },
         {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.3; en-us; LS670 Build\/GRI40) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "vendor": "Lava",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; IRIS_501 Build\/LAVAIRIS501) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
             "mobile": true,
             "tablet": false
         },
         {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; ru-ru; LG-E510 Build\/GRJ22) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1 MMS\/LG-Android-MMS-V1.0\/1.2",
+            "vendor": "Lava",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; iris402e Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
             "mobile": true,
             "tablet": false
         },
         {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; en-us; VS910 4G Build\/GRJ22) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "vendor": "Lava",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; iris503e Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
             "mobile": true,
             "tablet": false
         },
         {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; nl-nl; LG-P700 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "vendor": "Lava",
+            "user_agent": "UCWEB\/2.0 (Linux; U; Opera Mini\/7.1.32052\/30.3697; en-US; IRIS402) U2\/1.0.0 UCBrowser\/9.1.1.420 Mobile",
             "mobile": true,
             "tablet": false
         },
         {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build\/IML74K) AppleWebkit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "vendor": "Lava",
+            "user_agent": "UCWEB\/2.0 (MIDP-2.0; U; Adr 4.2.2; en-US; IRIS402) U2\/1.0.0 UCBrowser\/9.1.1.420 U2\/1.0.0 Mobile",
             "mobile": true,
             "tablet": false
         },
         {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; LG-F160S Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "vendor": "Lava",
+            "user_agent": "UCWEB\/2.0 (Linux; U; Opera Mini\/7.1.32052\/30.3697; en-US; IRIS355) U2\/1.0.0 UCBrowser\/9.1.1.420 Mobile",
             "mobile": true,
             "tablet": false
         },
         {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; nl-nl; LG-E610v\/V10f Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "vendor": "Lava",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; iris356 Build\/irisIRIS356) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 UCBrowser\/9.5.0.360 U3\/0.8.0 Mobile Safari\/533.1",
             "mobile": true,
             "tablet": false
         },
         {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; LG-E612 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "vendor": "Lava",
+            "user_agent": "UCWEB\/2.0 (Linux; U; Opera Mini\/7.1.32052\/30.3697; en-US; iris356) U2\/1.0.0 UCBrowser\/9.0.2.389 Mobile",
             "mobile": true,
             "tablet": false
         },
         {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; LG-F180K Build\/JZO54K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
+            "vendor": "Lava",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; iris500 Build\/iris500) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/30.0.0.0 Mobile Safari\/537.36",
             "mobile": true,
             "tablet": false
         },
         {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; LG-V500 Build\/JDQ39B) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/31.0.1650.59 Safari\/537.36",
+            "vendor": "Lava",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; iris700 Build\/iris700) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/30.0.0.0 Mobile Safari\/537.36",
             "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; LG-LW770 Build\/IMM76I) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; LG-V510 Build\/KOT49H.L004) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; LG; LG E-900)",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; LG; LG-C900)",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; LG; LG-C900k)",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; LG; LG-E900)",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; LG; LG-E900; Orange)",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; LG; LG-E900h)",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; LG; LG-Optimus 7)",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.0.1; ja-jp; L-06C Build\/HRI66) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.0; en-us; LG-V900 Build\/HRI39) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.4.2; en-gb; LG-V700 Build\/KOT49I.A1403851714) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/30.0.1599.103 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; LG-V500 Build\/KOT49I.V50020d) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/38.0.2125.102 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.4.2; en-us; LG-V410\/V41010d Build\/KOT49I.V41010d) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/30.0.1599.103 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "LG",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 7.0; LG-M257 Build\/NRD90U) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/66.0.3359.126 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "ASUS",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2.1; en-us; Transformer TF101 Build\/HTK75) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "3.2.1",
-                "Webkit": "534.13",
-                "Safari": "4.0"
-            },
-            "model": "Transformer TF101"
-        },
-        {
-            "vendor": "ASUS",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; Transformer Build\/JRO03L) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "ASUS",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; ASUS Transformer Pad TF300T Build\/JRO03C) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "ASUS",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; fr-fr; Transformer Build\/JZO54K; CyanogenMod-10) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "ASUS",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; asus_laptop Build\/IMM76L) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "ASUS",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; PadFone 2 Build\/JRO03L) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "ASUS",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; PadFone 2 Build\/JRO03L) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.1.1",
-                "Build": "JRO03L",
-                "Webkit": "534.30",
-                "Safari": "4.0"
-            }
-        },
-        {
-            "vendor": "ASUS",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.1; ME301T Build\/JOP40D) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Safari\/537.36",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.2.1",
-                "Build": "JOP40D"
-            }
-        },
-        {
-            "vendor": "ASUS",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.1; ME173X Build\/JOP40D) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Safari\/537.36",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.2.1",
-                "Build": "JOP40D"
-            }
-        },
-        {
-            "vendor": "ASUS",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; TF300T Build\/JDQ39E) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.2.2",
-                "Build": "JDQ39E"
-            }
-        },
-        {
-            "vendor": "ASUS",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; K00C Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "ASUS",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; K00E Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "ASUS",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; K00F Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "ASUS",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; K00L Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/36.0.1985.131 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "ASUS",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; ME302KL Build\/JDQ39) AppleWebKit\/537.31 (KHTML, like Gecko) Chrome\/26.0.1410.58 Safari\/537.31",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "ASUS",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; K010 Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/42.0.2311.111 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "ASUS",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; K017 Build\/KVT49L) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/42.0.2311.111 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "ASUS",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 5.0; PO1MA build\/LRX21V) AppelWebKit\/537.36 (KHTML, like Gecko) Chrome\/39.0.2171.93 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "ASUS",
-            "user_agent": "Mozilla\/5.0(Linus; Android 4.4.2; K011 Build\/KOT49H)AppleWebKit\/537.36 (KHTML, like Gecko)Chrome\/53.0.2785.124 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "ASUS",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 5.0.2; K01E Build\/LRX22G) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/39.0.2171.93 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "ASUS",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 5.0.2; P01Z Build\/LRX22G; wv) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "ASUS",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0; P027 Build\/MRA58L) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/56.0.2924.87 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "ASUS",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0.1; P024 Build\/MMB29M) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/61.0.3163.100 YaBrowser\/17.10.2.145.01 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "ASUS",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0.1; P024 Build\/MMB29M) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/58.0.3029.83 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "ASUS",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 7.0; P00C Build\/NRD90M) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/56.0.2924.87 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Dell",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 1.6; en-gb; Dell Streak Build\/Donut AppleWebKit\/528.5+ (KHTML, like Gecko) Version\/3.1.2 Mobile Safari\/ 525.20.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Dell",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.7; hd-us; Dell Venue Build\/GWK74; CyanogenMod-7.2.0) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Dell",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; DELL; Venue Pro)",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Dell",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; Venue 8 3830 Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Dell",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; Venue 7 3730 Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/30.0.0.0 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Dell",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; Venue 7 HSPA+ Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/37.0.2062.117 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Dell",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; en-us; Venue 8 3830 Build\/JSS15Q) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Dell",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2; zh-cn; Dell Streak 10 Pro Build\/HTJ85B) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Dell",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 7.0.1; en-US; Dell Streak 7 Build\/FRF91) AppleWebKit\/51.0 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/51.0",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Google",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2; en-us; Nexus One Build\/FRF91) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Google",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Nexus 4 Build\/JDQ39) AppleWebKit\/537.31 (KHTML, like Gecko) Chrome\/26.0.1410.40 Mobile Safari\/537.31 OPR\/14.0.1074.54070",
-            "mobile": true,
-            "tablet": false,
-            "version": {
-                "Android": "4.2.2",
-                "Build": "JDQ39",
-                "Webkit": "537.31",
-                "Opera": "14.0.1074.54070"
-            }
-        },
-        {
-            "vendor": "Google",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Nexus 4 Build\/JDQ39) AppleWebKit\/537.31 (KHTML, like Gecko) Chrome\/26.0.1410.58 Mobile Safari\/537.31",
-            "mobile": true,
-            "tablet": false,
-            "version": {
-                "Android": "4.2.2",
-                "Chrome": "26.0.1410.58"
-            }
-        },
-        {
-            "vendor": "Google",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; Google Nexus 4 - 4.1.1 - API 16 - 768x1280 Build\/JRO03S) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Google",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; Google Galaxy Nexus - 4.1.1 - API 16 - 720x1280 Build\/JRO03S) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Google",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; Nexus 7 Build\/JRO03D) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Google",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2; Nexus 7 Build\/JOP40C) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Google",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; Nexus 7 Build\/JZ054K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.1.2",
-                "Chrome": "18.0.1025.166"
-            }
-        },
-        {
-            "vendor": "Google",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; cs-cz; Nexus S Build\/JZO54K; CyanogenMod-10.0.0) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Google",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; Nexus 10 Build\/JWR66Y) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/29.0.1547.72 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Google",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android; en_us; Nexus 7 Build\/) AppleWebKit\/530.17 (KHTML, like Gecko) Version\/4.0 NetFrontLifeBrowser\/2.3 Mobile (Dragonfruit)",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Google",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 5.1; Nexus 5 Build\/LMY47D) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/39.0.0.0 Mobile Safari\/537.36 momoWebView\/6.3.1 android\/404(Nexus 5;android 5.1;zh_CN;10;netType\/1)",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Google",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; Nexus 10 Build\/JWR66Y) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/30.0.1599.92 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Google",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 7.1; Pixel XL Build\/NDE63H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/54.0.2840.85 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Google",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 7.1; Pixel Build\/NDE63H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/54.0.2840.85 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Google",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 8.1.0; Pixel C Build\/OPM1.171019.011; wv) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/65.0.3325.109 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Google",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 8.1.0; Pixel C Build\/OPM1.171019.026) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/66.0.3359.126 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Vodafone",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2; hu-hu; SmartTab10-MSM8260-V02d-Dec022011-Vodafone-HU) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Vodafone",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; SmartTabII10 Build\/IML74K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Vodafone",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; fr-fr; SmartTAB 1002 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Vodafone",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; de-de, SmartTabII7 Build\/A2107A_A404_107_055_130124_VODA) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "AdvanDigital",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; E1C Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "AdvanDigital",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; id-id; T3C Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Ainol",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; en-us; Ainol Novo8 Advanced Build\/GRJ22) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Ainol",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; Novo10 Hero Build\/20121115) AppleWebKit\/535.19 (KHTML like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Ainol",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; es-es; novo9-Spark Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "AllFine",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; FINE7 GENIUS Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Amoi",
-            "user_agent": "Amoi 8512\/R18.0 NF-Browser\/3.3",
-            "mobile": true,
-            "tablet": false,
-            "model": "8512"
-        },
-        {
-            "vendor": "Arnova",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; fr-fr; AN9G2I Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "AudioSonic",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-au; T-17B Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Blaupunkt",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; de-de; Endeavour 800NG Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Broncho",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2; es-es; Broncho N701 Build\/FRF91) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "bq",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; es-es; bq Livingstone 2 Build\/1.1.7 20121018-10:33) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "bq",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; es-es; bq Edison Build\/1.1.10-1015 20121230-18:00) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "bq",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; Maxwell Lite Build\/v1.0.0.ICS.maxwell.20120920) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "bq",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; zh-tw; bq Maxwell Plus Build\/1.0.0 20120913-10:39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "bq",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; Aquaris E10 Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/39.0.2171.93 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "bq",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 5.1; Aquaris M10 Build\/LMY47I) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/47.0.2526.83 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "bq",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0; Aquaris M10 FHD Build\/MRA58K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/58.0.3029.83 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "bq",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0; Aquaris M8 Build\/MRA58K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/60.0.3112.116 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "bq",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.4; Aquaris E5 Build\/KTU84P) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/57.0.2987.132 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "bq",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 5.0; Aquaris E5 HD Build\/LRX21M) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/55.0.2883.91 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "bq",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0; Aquaris_M4.5 Build\/MRA58K; wv) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/51.0.2704.81 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "bq",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0.1; Aquaris X5 Build\/MMB29M) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/52.0.2743.91 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "bq",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; Aquaris E4 Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/61.0.3163.98 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "bq",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 5.0.2; Aquaris M5 Build\/LRX22G) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/61.0.3163.98 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Captiva",
-            "user_agent": "Opera\/9.80 (X11; Linux zvav; U; de) Presto\/2.8.119 Version\/11.10 Mozilla\/5.0 (Linux; U; Android 4.1.1; de-de; CAPTIVA PAD 10.1 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Casio",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.3; en-us; C771 Build\/C771M120) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "ChangJia",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; pt-br; TPC97113 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "ChangJia",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; TPC7102 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Celkon",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; en-us; Celkon CT 910+ Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Celkon",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-in; CT-1 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Celkon",
-            "user_agent": "CELKON.C64\/R2AE SEMC-Browser\/4.0.3 Profile\/MIDP-2.0 Configuration\/CLDC-1.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Celkon",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; Celkon A125 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Celkon",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.6; en-US; Celkon*A86 Build\/Celkon_A86) AppleWebKit\/528.5+ (KHTML, like Gecko) Version\/3.1.2 Mobile Safari\/525.20.1 UCBrowser\/8.7.0.315 Mobile",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Celkon",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; Celkon A.R 40 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Coby",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2; en-us; MID7010 Build\/FRF85B) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Coby",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; MID7048 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Coby",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; MID8042 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Concorde",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; hu-hu; ConCorde Tab T10 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Concorde",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; hu-hu; ConCorde tab PLAY Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Cresta",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; nl-nl; CRESTA.CTP888 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Cube",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; ru-ru; CUBE U9GT 2 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Danew",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; es-es; Dslide 700 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.0.3",
-                "Build": "IML74K",
-                "Webkit": "534.30",
-                "Safari": "4.0"
-            },
-            "model": "Dslide 700"
-        },
-        {
-            "vendor": "DanyTech",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Genius Tab Q4 Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/31.0.1650.59 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Digma",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; ru-ru; iDx10 3G Build\/ICS.b02ref.20120331) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "DPS",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; DPS Dream 9 Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "ECS",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; it-it; TM105A Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.0.4",
-                "Build": "IMM76D",
-                "Webkit": "534.30"
-            }
-        },
-        {
-            "vendor": "Eboda",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; ro-ro; E-Boda Supreme Dual Core X190 Build\/JRO03C) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.1.1",
-                "Webkit": "534.30",
-                "Safari": "4.0"
-            }
-        },
-        {
-            "vendor": "Eboda",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; ro-ro; E-Boda Essential A160 Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Eboda",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; E-Boda Supreme X80 Dual Core Build\/ICS.g12refM806A1YBD.20120925) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Eboda",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; ro-ro; E-boda essential smile Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Eboda",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; ro-ro; E-Boda Supreme X80 Dual Core Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Eboda",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; ro-ro; E-Boda Supreme XL200IPS Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Evolio",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; Evolio X7 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Evolio",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; ro-ro; ARIA_Mini_wifi Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Fly",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; ru-ru; Fly IQ440; Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Fly",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.6; ru-ru; FLY IQ256 Build\/GRK39F) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Fujitsu",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; ja-jp; F-10D Build\/V21R48A) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.0.3",
-                "Build": "V21R48A",
-                "Webkit": "534.30",
-                "Safari": "4.0"
-            }
-        },
-        {
-            "vendor": "Fujitsu",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; ru-ru; M532 Build\/IML74K) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.0.3",
-                "Build": "IML74K",
-                "Webkit": "534.30",
-                "Safari": "4.0"
-            }
-        },
-        {
-            "vendor": "FX2",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; FX2 PAD7 RK Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Galapad",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; zh-tw; G1 Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.1.1",
-                "Webkit": "534.30",
-                "Safari": "4.0",
-                "Build": "JRO03C"
-            }
-        },
-        {
-            "vendor": "GoClever",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; el-gr; GOCLEVER TAB A103 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "GoClever",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; zh-tw; A7GOCLEVER Build\/GRJ22) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "GoClever",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; GOCLEVER TAB A104 Build\/IMM76D) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "GoClever",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; cs-cz; GOCLEVER TAB A93.2 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "GoClever",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; sk-sk; GOCLEVER TAB A971 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "GoClever",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; lv-lv; GOCLEVER TAB A972BK Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "GoClever",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; fr-fr; GOCLEVER TAB A104.2 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "GoClever",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; pt-pt; GOCLEVER TAB T76 Build\/MID) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "GU",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; vi-vn; TX-A1301 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.0.4",
-                "Build": "IMM76D",
-                "Webkit": "534.30",
-                "Safari": "4.0"
-            }
-        },
-        {
-            "vendor": "GU",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; da-dk; Q702 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.0.3",
-                "Build": "IML74K",
-                "Webkit": "534.30",
-                "Safari": "4.0"
-            }
-        },
-        {
-            "vendor": "HCL",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; U1 Build\/HCL ME Tablet U1) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "HCL",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; U1 Build\/HCL ME Tablet U1) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "HCL",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; Connect-3G-2.0 Build\/HCL) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/29.0.1547.72 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "HCL",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.3; pt-br; X1 Build\/HCL ME Tablet X1) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Hisense",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.4; F5281 Build\/KTU84Q) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/260.1985.135 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Hudl",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Hudl HT7S3 Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/30.0.1599.82 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Iconbit",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; NT-3702M Build\/JRO03C) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/29.0.1547.72 Safari\/537.36 OPR\/16.0.1212.65583",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Iconbit",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; ru-ru; NetTAB SPACE II Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "iJoy",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; fr-fr; Tablet Planet II-v3 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Intenso",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1.;de-de; INM8002KP Build\/JR003H) AppleWebKit\/534.30 (KHTML, like Gecko)Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.1.1.",
-                "Webkit": "534.30",
-                "Safari": "4.0"
-            }
-        },
-        {
-            "vendor": "Intenso",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; TAB1004 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "INQ",
-            "user_agent": "INQ1\/R3.9.12 NF-Browser\/3.5",
-            "mobile": true,
-            "tablet": false,
-            "model": "INQ1"
-        },
-        {
-            "vendor": "Intex",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3; en-US; Cloud_X2 Build\/MocorDroid4.0.1) AppleWebKit\/528.5+ (KHTML, like Gecko) Version\/3.1.2 Mobile Safari\/525.20.1 UCBrowser\/9.2.0.419 Mobile",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Intex",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; Cloud Y2 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Intex",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-in; Cloud X5 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "IRU",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; ru-ru; M702pro Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "JXD",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; F3000 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Karbonn",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; ST10 Build\/JRO03C) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "KRAMER",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0; KT107 Build\/LMY47I) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/64.0.3282.137 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Kobo",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.0; en-us;) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1 (Kobo Touch)",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "2.0",
-                "Webkit": "533.1",
-                "Safari": "4.0"
-            }
-        },
-        {
-            "vendor": "Megafon",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.5; ru-ru; MegaFon V9 Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Megafon",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; MT7A Build\/JRO03C) AppleWebKit\/537.31 (KHTML, like Gecko) Chrome\/26.0.1410.58 Safari\/537.31",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Mediacom",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0.1; M-MPI10C3G Build\/MMB29M) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/64.0.3282.137 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "MediaTek",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; fr-fr; MT8377 Build\/JRO03C) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30\/4.05d.1002.m7",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Micromax",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; Micromax A110 Build\/JRO03C) AppleWebKit\/537.22 (KHTML, like Gecko) Chrome\/25.0.1364.169 Mobile Safari\/537.22",
-            "mobile": true,
-            "tablet": false,
-            "version": {
-                "Android": "4.1.1",
-                "Build": "JRO03C",
-                "Webkit": "537.22",
-                "Chrome": "25.0.1364.169"
-            }
-        },
-        {
-            "vendor": "Micromax",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0; xx-xx; Micromax P250(Funbook) Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Webkit": "534.30",
-                "Android": "4.0",
-                "Build": "IMM76D",
-                "Safari": "4.0"
-            }
-        },
-        {
-            "vendor": "Modecom",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; pl-pl; FreeTAB 1014 IPS X4+ Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "MSI",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.5; el-gr; MSI Enjoy 10 Plus Build\/1.2) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Nabi",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2.1; en-us; NABI-A Build\/MASTER) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "NEC",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; ja-jp; N-08D Build\/A5001911) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "NEC",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android AAA; BBB; N-06D Build\/CCC) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Nexo",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; pl-pl; NEXO 3G Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30 ACHEETAHI\/2100050074",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Nibiru",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; zh-tw; Nibiru H1 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30 XiaoMi\/MiuiBrowser\/1.0",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Nook",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2.1; en-us; NOOK BNRV200 Build\/ERD79 1.4.3) Apple WebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "2.2.1",
-                "Webkit": "533.1",
-                "Safari": "4.0"
-            }
-        },
-        {
-            "vendor": "Nook",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; NOOK BNTV400 Build\/ICS) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.0.4",
-                "Build": "ICS",
-                "Webkit": "534.30",
-                "Safari": "4.0"
-            }
-        },
-        {
-            "vendor": "Nook",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; BNTV600 Build\/IMM76L) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Safari\/537.36 Hughes-PFB\/CID5391275.AID1376709964",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.0.4",
-                "Build": "IMM76L",
-                "Webkit": "537.36",
-                "Chrome": "28.0.1500.94"
-            }
-        },
-        {
-            "vendor": "Oneplus",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; A0001 Build\/JLS36C) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Oneplus",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; xx-xx; A0001 Build\/JLS36C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Oneplus",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 7.1.1; ONEPLUS A5000 Build\/NMF26X; wv) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/60.0.3112.116 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Oneplus",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 8.1.0; ONEPLUS A5010 Build\/OPM1.171019.011; wv) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/66.0.3359.126 Mobile Safari\/537.36 [FB_IAB\/Orca-Android;FBAV\/164.0.0.24.95;]",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Odys",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; de-de; LOOX Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Odys",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; de-de; LOOX Plus Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Odys",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.X; de-de; XENO10 Build\/ODYS XENO 10) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Odys",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2.2; de-de; ODYS Space Build\/I700T_P7_T04_TSCL_FT_R_0_03_1010_110623) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Odys",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; de-de; ODYS-EVO Build\/ODYS-EVO) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Odys",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.X; de-de; Xelio 10 Pro Build\/ODYS_Xelio) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Odys",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; NEO_QUAD10 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Odys",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.X; de-de; Xelio10Pro Build\/ODYS_Xelio) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Odys",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.1; en-us; ODYS-Xpress Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Odys",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; de-de; XELIO7PHONETAB Build\/IMM76I) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Odys",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; XELIO10EXTREME Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Odys",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; de-de; XELIO Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30 Mobile UCBrowser\/3.2.1.441",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Odys",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; XELIOPT2 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Odys",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; nl-nl; ODYS-NOON Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "OverMax",
-            "user_agent": "OV-SteelCore(B) Mozilla\/5.0 (iPad; CPU OS 5_0_1 like Mac OS X) AppleWebKit\/534.46 (KHTML, like Gecko) Version\/5.1 Mobile\/9A405 Safari\/7534.48.3",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "OverMax",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; pl-pl; OV-SteelCore Build\/ICS.g08refem611.20121010) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "OverMax",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 7.0.99; Qualcore 1027 4G Build\/LMY47D) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/60.0.3112.116 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "YONESTablet",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; pl-pl; BC1077 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Pantech",
-            "user_agent": "PANTECH-C790\/JAUS08312009 Browser\/Obigo\/Q05A Profile\/MIDP-2.0 Configuration\/CLDC-1.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Pantech",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2.1; ko-kr; SKY IM-A600S Build\/FRG83) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Pantech",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.3; en-us; ADR8995 4G Build\/GRI40) AppleWebKit\/533.1 (KHTML like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Pantech",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2.1; en-us; PantechP4100 Build\/HTK75) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Philips",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; Philips W336 Build\/IMM76D) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.45 Mobile Safari\/537.36 OPR\/15.0.1162.59192",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Philips",
-            "user_agent": "Philips_T3500\/V1 Linux\/3.4.5 Android\/4.2.2 Release\/03.26.2013 Browser\/AppleWebKit534.30 Mobile Safari\/534.30 MBBMS\/2.2 System\/Android 4.2.2;",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Philips",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Philips W3568 Build\/Philips_W3568) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Philips",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; ru-ru; Philips W832 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Philips",
-            "user_agent": "Mozilla\/5.0 (Linux;U;Android 4.2.2;es-us;Philips S388 Build\/JDQ39) AppleWebkit\/534.30 (HTML,like Gecko) Version\/4.0 Mobile Safari\/534.30;",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Philips",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; Philips W536 Build\/IMM76D) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Philips",
-            "user_agent": "Mozilla\/5.0 (Linux;U;Android 4.2.2;es-us;Philips S308 Build\/JDQ39) AppleWebkit\/534.30 (HTML,like Gecko) Version\/4.0 Mobile Safari\/534.30;",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Philips",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; ru-ru; Philips-W8500 Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Philips",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; ru; Philips W8510 Build\/JDQ39) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 UCBrowser\/9.8.9.457 U3\/0.8.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Philips",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; ru-RU; Philips W3568 Build\/Philips W3568) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.1 Mobile Safari\/534.30;",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Philips",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Philips S388 Build\/JDQ39) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Philips",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; Build\/PI3100.00.00.24) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Philips",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; W732 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Philips",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.1; PI7100_93 Build\/PI7100.C.00.00.11) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/30.0.1599.92 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "PocketBook",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.7; en-ru; PocketBook A10 3G Build\/GRJ90) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "PointOfView",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; POV_TAB-PROTAB30-IPS10 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Polaroid",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 5.1.1; MID4X10 Build\/LMY47V) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/48.0.2564.95 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Praktica",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; TP750 3GGSM Build\/IMM76I) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/39.0.2171.93 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "PROSCAN",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; PLT8088 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.1.1",
-                "Build": "JRO03H",
-                "Webkit": "534.30",
-                "Safari": "4.0"
-            }
-        },
-        {
-            "vendor": "PyleAudio",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; PTBL92BC Build\/IMM76D) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/31.0.1650.59 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.0.4",
-                "Build": "IMM76D",
-                "Webkit": "537.36",
-                "Chrome": "31.0.1650.59"
-            }
-        },
-        {
-            "vendor": "RockChip",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2.1; hu-hu; RK2818, Build\/MASTER) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "RockChip",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android Android 2.1-RK2818-1.0.0; zh-cn; MD701 Build\/ECLAIR) AppleWebKit\/530.17 (KHTML like Gecko) Version\/4.0 Mobile Safari\/530.17",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "RossMoor",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.1; ru-ru; RM-790 Build\/JOP40D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "QMobile",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.6; en-us; A2 Build\/GRK39F) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "simvalley",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; de-de; SP-80 Build\/GRJ22) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Skk",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1; en-us; CYCLOPS Build\/F10) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Storex",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; eZee_Tab903 Build\/JRO03H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Safari\/537.36",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.1.1",
-                "Build": "JRO03H",
-                "Webkit": "537.36"
-            }
-        },
-        {
-            "vendor": "Storex",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; eZee'Tab785 Build\/JRO03C) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/31.0.1650.59 Safari\/537.36",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.1.1",
-                "Build": "JRO03C",
-                "Webkit": "537.36"
-            }
-        },
-        {
-            "vendor": "Storex",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; eZee'Tab971 Build\/IML74K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.0.3",
-                "Build": "IML74K",
-                "Webkit": "535.19"
-            }
-        },
-        {
-            "vendor": "Teclast",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; P98 3G\\xE5\\x85\\xAB\\xE6\\xA0\\xB8(A3HY) Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/30.0.0.0 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Teclast",
-            "user_agent": "QQ\\xe9\\x9f\\xb3\\xe4\\xb9\\x90HD 4.0.1 (iPad; iPhone OS 8.0; zh_CN)",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Teclast",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0; xx-xx; A15(E6C2) Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Teclast",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3; xx-xx; A10 Build\/GRJ22) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Teclast",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; Teclast A10T Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Teclast",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; zh-cn; Teclast P85(A9D3) Build\/IMM76D) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Teclast",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; A70H Build\/JDQ39) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 UCBrowser\/9.8.0.435 U3\/0.8.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Tecno",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; TECNO P9 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Tecno",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 5.1; TECNO DP8D Build\/LMY47D) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/49.0.2623.91 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Telstra",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.7; en-au; T-Hub2 Build\/TVA301TELBG3) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "texet",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; ru-ru; TM-7021 Build\/GB.m1ref.20120116) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "2.3.4",
-                "Webkit": "533.1",
-                "Safari": "4.0"
-            },
-            "model": "TM-7021"
-        },
-        {
-            "vendor": "Tolino",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; tolino tab 7 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.2.2",
-                "Build": "JDQ39",
-                "Webkit": "534.30",
-                "Safari": "4.0"
-            }
-        },
-        {
-            "vendor": "Tolino",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; tolino tab 8.9 Build\/JDQ39) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.2.2",
-                "Build": "JDQ39",
-                "Webkit": "534.30",
-                "Safari": "4.0"
-            }
-        },
-        {
-            "vendor": "Tolino",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; tolino tab 7 Build\/JDQ39) AppleWebkit\/537.36 (KHTML, like Gecko) Chrome\/31.0.1650.57 Safari\/537.36 OPR\/18.0.1290.67495",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Tolino",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; tolino tab 7 Build\/JDQ39) AppleWebkit\/537.36 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Toshiba",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; TOSHIBA; TSUNAGI)",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Toshiba",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2; it-it; TOSHIBA_FOLIO_AND_A Build\/TOSHIBA_FOLIO_AND_A) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "2.2",
-                "Webkit": "533.1",
-                "Safari": "4.0"
-            }
-        },
-        {
-            "vendor": "Trekstor",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; ST70408-1 Build\/JDQ39) AppleWebKit\/537.31 (KHTML, like Gecko) Chrome\/26.0.1410.58 Safari\/537.31",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.2.2",
-                "Build": "JDQ39",
-                "Webkit": "537.31",
-                "Chrome": "26.0.1410.58"
-            }
-        },
-        {
-            "vendor": "Trekstor",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; engb; Build\/IMM76D) AppleWebKit\/534.46 (KHTML, like Gecko) Version\/5.1 Mobile\/9A405 Safari\/7534.48.3 SurfTab_7.0",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Trekstor",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; VT10416-2 Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Trekstor",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; de-de; ST10216-2A Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30;SurfTab_10.1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Tsmine",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; TM1088 Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/66.0.3359.126 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Ubislate",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; UBISLATE7C+ Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "WeVool",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 5.0; WVT101 Build\/LRX21M) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/66.0.3359.126 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Visture",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-gb; V97 HD Build\/LR-97JC) Apple WebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Visture",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; Visture V4 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Visture",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; ru-ru; Visture V4 HD Build\/Visture V4 HD) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Visture",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; es-es; Visture V5 HD Build\/Visture V5 HD) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Visture",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; ru-ru; Visture V10 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Versus",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; VS-TOUCHPAD 9 Build\/IMM76D) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Versus",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-gb; Versus Touchpad 9.7 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Versus",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-gb; CnM-TOUCHPAD7 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30 BMID\/E67A45B1AB",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Versus",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; CnM TouchPad 7DC Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30 TwonkyBeamBrowser\/3.3.5-95 (Android 4.1.1; rockchip CnM TouchPad 7DC Build\/meizhi_V2.80.wifi8723.20121225.b11c800)",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Versus",
-            "user_agent": "OneBrowser\/3.5\/Mozilla\/5.0 (Linux; U; Android 4.0.4; en-gb; TOUCHPAD 7 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Versus",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; TOUCHTAB Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.1.1",
-                "Build": "JRO03H",
-                "Webkit": "534.30",
-                "Safari": "4.0"
-            }
-        },
-        {
-            "vendor": "Viewsonic",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; de-de; ViewPad 10e Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Viewsonic",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2; it-it; ViewPad7 Build\/FRF91) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Viewsonic",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2.1; en-ca; ViewSonic VB733 Build\/FRG83) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Viewsonic",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2; en-gb; ViewPad7X Build\/HTJ85B) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Safari\/533.1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Viewsonic",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2; pt-br; ViewPad 10S Build\/FRF91) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Viewsonic",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; VB100a Pro Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Vonino",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; Sirius_Evo_QS Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Vonino",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; Q8 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Wolder",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4; miTab LIVE Build\/KVT49L) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/30.0.0.0 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Wolder",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; pt-pt; miTab FUNK Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Wolfgang",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.1; nl-nl; AT-AS45q2 Build\/JOP40D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Xoro",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; PAD 9720QR Build\/PAD 9719QR) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Xoro",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; PAD720 Build\/JDQ39) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "ZTE",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; V8200plus Build\/IMM76I) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/33.0.1750.166 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Zync",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.3; en-us ; Z909 Build\/GRI40) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1\/UCBrowser\/8.4.1.204\/145\/444",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": 0,
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-au; TBLT10Q-32GB Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Avant",
-            "user_agent": "Mozilla\/5.0 (Windows NT 6.1; WOW64; Trident\/7.0; Avant Browser; rv:11.0) like Gecko",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Avant",
-            "user_agent": "Mozilla\/5.0 (Windows NT 6.1; WOW64; Avant TriCore) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/30.0.1599.101 Safari\/537.36",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Avant",
-            "user_agent": "Mozilla\/5.0 (Windows NT 5.1; rv:27.0; Avant TriCore) Gecko\/20100101 Firefox\/27.0",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Console",
-            "user_agent": "Mozilla\/5.0 (Nintendo WiiU) AppleWebKit\/536.28 (KHTML, like Gecko) NX\/3.0.3.12.14 NintendoBrowser\/3.1.1.9577.EU",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Console",
-            "user_agent": "Mozilla\/5.0 (Nintendo WiiU) AppleWebKit\/534.52 (KHTML, like Gecko) NX\/{Version No} NintendoBrowser\/{Version No}.US",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Console",
-            "user_agent": "Mozilla\/5.0 (Nintendo 3DS; U; ; en) Version\/1.7567.US",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Console",
-            "user_agent": "Mozilla\/5.0 (Nintendo 3DS; U; ; en) Version\/1.7498.US",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Console",
-            "user_agent": "Mozilla\/5.0 (PLAYSTATION 3 4.21) AppleWebKit\/531.22.8 (KHTML, like Gecko)",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Console",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident\/5.0; Xbox)",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/53.0.2785.148 Safari\/537.36 Vivaldi\/1.4.589.41",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Mozilla\/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident\/4.0; SV1; [eburo v4.0]; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; InfoPath.3; .NET4.0C; .NET4.0E)",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_10) AppleWebKit\/600.1.25 (KHTML, like Gecko) Version\/8.0 Safari\/600.1.25",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/38.0.2125.111 Safari\/537.36",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Mozilla\/5.0 (Windows NT 6.1) AppleWebKit\/537.36 (KHTML, like Gecko) Iron\/37.0.2000.0 Chrome\/37.0.2000.0 Safari\/537.36",
-            "mobile": false,
-            "tablet": false,
-            "version": {
-                "Iron": "37.0.2000.0"
-            }
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Mozilla\/5.0 (X11; Linux i686) AppleWebKit\/537.36 (KHTML, like Gecko) Ubuntu Chromium\/32.0.1700.102 Chrome\/32.0.1700.102 Safari\/537.36",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Mozilla\/5.0 (Windows NT 6.1; WOW64; rv:24.0) Gecko\/20100101 Firefox\/24.0",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Mozilla\/5.0 (Windows NT 6.1; WOW64; rv:18.0) Gecko\/20100101 Firefox\/18.0 AlexaToolbar\/psPCtGhf-2.2",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Mozilla\/5.0 (X11; Ubuntu; Linux x86_64; rv:22.0) Gecko\/20100101 Firefox\/22.0",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Mozilla\/5.0 (X11; Linux ppc; rv:17.0) Gecko\/20130626 Firefox\/17.0 Iceweasel\/17.0.7",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Mozilla\/5.0 (X11; Linux) AppleWebKit\/535.22+ Midori\/0.4",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Mozilla\/5.0 (Macintosh; U; Intel Mac OS X; en-us) AppleWebKit\/535+ (KHTML, like Gecko) Version\/5.0 Safari\/535.20+ Midori\/0.4",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Mozilla\/5.0 (Windows NT 6.2; WOW64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.20 Safari\/537.36  OPR\/15.0.1147.18 (Edition Next)",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Mozilla\/5.0 (Windows NT 6.2) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.94 Safari\/537.36",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Mozilla\/5.0 (Windows NT 5.2; WOW64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.94 Safari\/537.36",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Mozilla\/5.0 (Windows NT 5.2; WOW64; rv:21.0) Gecko\/20100101 Firefox\/21.0",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Opera\/9.80 (Windows NT 5.2; WOW64) Presto\/2.12.388 Version\/12.14",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Mozilla\/5.0 (Windows NT 6.1; WOW64; rv:19.0) Gecko\/20100101 Firefox\/19.0",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Mozilla\/5.0 (X11; FreeBSD amd64; rv:14.0) Gecko\/20100101 Firefox\/14.0.1",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Mozilla\/4.0 (compatible; MSIE 7.0; Windows NT 6.2; Win64; x64; Trident\/6.0; Touch; .NET4.0E; .NET4.0C; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET CLR 2.0.50727; Tablet PC 2.0; MASMJS)",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident\/6.0; MANMJS)",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Win64; x64; Trident\/6.0; MASMJS)",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident\/6.0; Touch; MASMJS)",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Opera\/9.80 (Windows NT 6.2; WOW64; MRA 8.0 (build 5784)) Presto\/2.12.388 Version\/12.11",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident\/6.0)",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Mozilla\/5.0 (Windows NT 6.3; Trident\/7.0; rv 11.0) like Gecko",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Mozilla\/5.0 (Windows NT 6.3; WOW64; Trident\/7.0; Touch; rv:11.0) like Gecko",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Mozilla\/5.0 (Unknown; Linux armv7l) AppleWebKit\/537.1+ (KHTML, like Gecko) Safari\/537.1+ HbbTV\/1.1.1 ( ;LGE ;NetCast 4.0 ;03.20.30 ;1.0M ;)",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "HbbTV\/1.1.1 (;Panasonic;VIERA 2012;1.261;0071-3103 2000-0000;)",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Other",
-            "user_agent": "Opera\/9.80 (Linux armv7l; HbbTV\/1.1.1 (; Sony; KDL32W650A; PKG3.211EUA; 2013;); ) Presto\/2.12.362 Version\/12.11",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "TV",
-            "user_agent": "Mozilla\/5.0 (SMART-TV; Linux; Tizen 2.3) AppleWebkit\/538.1 (KHTML, like Gecko) SamsungBrowser\/1.0 TV Safari\/538.1",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (Windows NT 10.0; Win64; x64; rv:38.9) Gecko\/20100101 Goanna\/2.0 Firefox\/38.9 PaleMoon\/26.0.0",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (Windows NT 10.0; Win64; x64; rv:2.0) Gecko\/20100101 Goanna\/20160121 PaleMoon\/26.0.0",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (Windows NT 10.0; Win64; x64; rv:38.9) Gecko\/20100101 Goanna\/2.0 Firefox\/38.9 PaleMoon\/26.1.1",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (Maemo; Linux; U; Jolla; Sailfish; Mobile; rv:31.0) Gecko\/31.0 Firefox\/31.0 SailfishBrowser\/1.0",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (Maemo; Linux; U; Jolla; Sailfish; Tablet; rv:31.0) Gecko\/31.0 Firefox\/31.0 SailfishBrowser\/1.0",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (Mobile; rv:26.0) Gecko\/26.0 Firefox\/26.0",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (Tablet; rv:26.0) Gecko\/26.0 Firefox\/26.0",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; CT1020W Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; M6pro Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "MobileSafari\/9537.53 CFNetwork\/672.1.13 Darwin\/13.1.0",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Appcelerator Titanium\/3.2.2.GA (iPod touch\/6.1.6; iPhone OS; en_US;)",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Opera Coast\/3.0.3.78307 CFNetwork\/672.1.15 Darwin\/14.0.0",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; ALUMIUM10 Build\/IML74K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.1; en-us; JY-G3 Build\/JOP40D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; hu-hu; M758A Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; EVOTAB Build\/IMM76I) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Java\/1.6.0_22",
-            "mobile": false,
-            "tablet": false,
-            "version": {
-                "Java": "1.6.0_22"
-            }
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Opera\/9.80 (Series 60; Opera Mini\/6.5.29260\/29.3417; U; ru) Presto\/2.8.119 Version\/11.10",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Opera\/9.80 (Android; Opera Mini\/6.5.27452\/29.3417; U; ru) Presto\/2.8.119 Version\/11.10",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Opera\/9.80 (iPhone; Opera Mini\/7.1.32694\/27.1407; U; en) Presto\/2.8.119 Version\/11.10",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (Windows NT 6.1; WOW64) AppleWebKit\/537.17 (KHTML, like Gecko) Chrome\/24.0.1312.60 Safari\/537.17 OPR\/14.0.1025.52315",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (iPhone; U; CPU iPhone OS 4_3_2 like Mac OS X; en-us) AppleWebKit\/533.17.9 (KHTML, like Gecko) Version\/5.0.2 Mobile\/8H7 Safari\/6533.18.5",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Opera\/9.80 (Android 2.3.7; Linux; Opera Mobi\/46154) Presto\/2.11.355 Version\/12.10",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (iPad; CPU OS 6_1 like Mac OS X) AppleWebKit\/536.26 (KHTML, like Gecko) Version\/6.0 Mobile\/10B141 Safari\/8536.25",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; en-us; sdk Build\/MASTER) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2; en-us; sdk Build\/JB_MR1) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (Android; Mobile; rv:18.0) Gecko\/18.0 Firefox\/18.0",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (Windows NT 6.1) AppleWebKit\/535.12 (KHTML, like Gecko) Maxthon\/3.0 Chrome\/18.0.966.0 Safari\/535.12",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Opera\/9.80 (Windows NT 5.1; U; Edition Yx; ru) Presto\/2.10.289 Version\/12.02",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/4.0 (compatible; MSIE 6.0; Windows NT 5.1; Windows Phone 6.5.3.5)",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "PalmCentro\/v0001 Mozilla\/4.0 (compatible; MSIE 6.0; Windows 98; PalmSource\/Palm-D061; Blazer\/4.5) 16;320x320",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0)",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Microsoft; XDeviceEmulator)",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; MAL; N880E; China Telecom)",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Opera\/9.80 (Series 60; Opera Mini\/7.0.29482\/28.2859; U; ru) Presto\/2.8.119 Version\/11.10",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Opera\/9.80 (S60; SymbOS; Opera Mobi\/SYB-1202242143; U; en-GB) Presto\/2.10.254 Version\/12.00",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-au; 97D Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Opera\/9.80 (Android; Opera Mini\/7.0.29952\/28.2647; U; ru) Presto\/2.8.119 Version\/11.10",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Opera\/9.80 (Android; Opera Mini\/6.1.25375\/28.2555; U; en) Presto\/2.8.119 Version\/11.10",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Opera\/9.80 (Mac OS X; Opera Tablet\/35779; U; en) Presto\/2.10.254 Version\/12.00",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (Android; Tablet; rv:10.0.4) Gecko\/10.0.4 Firefox\/10.0.4 Fennec\/10.0.4",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (Android; Tablet; rv:18.0) Gecko\/18.0 Firefox\/18.0",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Opera\/9.80 (Linux armv7l; Maemo; Opera Mobi\/14; U; en) Presto\/2.9.201 Version\/11.50",
-            "mobile": true,
             "tablet": false
         },
         {
-            "vendor": "Generic",
-            "user_agent": "Opera\/9.80 (Android 2.2.1; Linux; Opera Mobi\/ADR-1207201819; U; en) Presto\/2.10.254 Version\/12.00",
+            "vendor": "Lava",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; QPAD E704 Build\/JDQ39) AppleWebKit\/537.36 (KHTML like Gecko) Chrome\/36.0.1985.131 Safari\/537.36",
             "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; sdk Build\/JRO03E) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; Endeavour 1010 Build\/ONDA_MID) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; de-de; Tablet-PC-4 Build\/ICS.g08refem618.20121102) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Generic",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; Tagi Tab S10 Build\/8089) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Bot",
-            "user_agent": "Mozilla\/5.0 (compatible; Googlebot\/2.1; +http:\/\/www.google.com\/bot.html)",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Bot",
-            "user_agent": "grub-client-1.5.3; (grub-client-1.5.3; Crawl your own stuff with http:\/\/grub.org)",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Bot",
-            "user_agent": "Googlebot-Image\/1.0",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Bot",
-            "user_agent": "Python-urllib\/2.5",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Bot",
-            "user_agent": "facebookexternalhit\/1.0 (+http:\/\/www.facebook.com\/externalhit_uatext.php)",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Bot",
-            "user_agent": "AdsBot-Google (+http:\/\/www.google.com\/adsbot.html)",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Bot",
-            "user_agent": "AdsBot-Google-Mobile (+http:\/\/www.google.com\/mobile\/adsbot.html) Mozilla (iPhone; U; CPU iPhone OS 3 0 like Mac OS X) AppleWebKit (KHTML, like Gecko) Mobile Safari",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Bot",
-            "user_agent": "Mozilla\/5.0 (X11; U; Linux x86_64; en-US) AppleWebKit\/534.16 (KHTML, like Gecko, Google Keyword Suggestion) Chrome\/10.0.648.127 Safari\/534.16",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Bot",
-            "user_agent": "Facebot",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "HP",
-            "user_agent": "Mozilla\/5.0 (hp-tablet; Linux; hpwOS\/3.0.5; U; en-GB) AppleWebKit\/534.6 (KHTML, like Gecko) wOSBrowser\/234.83 Safari\/534.6 TouchPad\/1.0",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "HP",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; HP Slate 7 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "HP",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; HP Slate 7 Build\/JRO03H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "HP",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; HP 8 Build\/1.0.7_WW-FIR-13) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "HP",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; HP Slate 10 HD Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
-            "mobile": true,
             "tablet": true
         },
         {
-            "vendor": "HP",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; HP Slate 8 Pro Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
+            "vendor": "Lava",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2; xx-xx; IvoryS Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
             "mobile": true,
             "tablet": true
         },
         {
-            "vendor": "HP",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Slate 21 Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.138 Safari\/537.36 OPR\/22.0.1485.78487",
+            "vendor": "Lava",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; en-US; E-TAB IVORY Build\/E702) AppleWebKit\/534.31 (KHTML, like Gecko) UCBrowser\/9.3.0.321 U3\/0.8.0 Mobile Safari\/534.31",
             "mobile": true,
             "tablet": true
         },
         {
-            "vendor": "HP",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; HP SlateBook 10 x2 PC Build\/4.3-17r20-03-23) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Safari\/537.36",
+            "vendor": "Lava",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; tr-tr; E-TAB Build\/GRJ22) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
             "mobile": true,
             "tablet": true
-        },
-        {
-            "vendor": "Amazon",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; KFTT Build\/IML74K) AppleWebKit\/535.19 (KHTML, like Gecko) Silk\/3.4 Mobile Safari\/535.19 Silk-Accelerated =true",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Amazon",
-            "user_agent": "Mozilla\/5.0 (Linux; U; en-US) AppleWebKit\/528.5+ (KHTML, like Gecko, Safari\/528.5+) Version\/4.0 Kindle\/3.0 (screen 600x800; rotate)",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Webkit": "528.5+",
-                "Kindle": "3.0",
-                "Safari": "4.0"
-            },
-            "model": "Kindle"
-        },
-        {
-            "vendor": "Amazon",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; KFOTE Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.0.3",
-                "Build": "IML74K",
-                "Webkit": "534.30",
-                "Safari": "4.0"
-            }
-        },
-        {
-            "vendor": "Amazon",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; WFJWAE Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Amazon",
-            "user_agent": "Mozilla\/5.0 (Linux; U; en-us; KFTT Build\/IML74K) AppleWebKit\/535.19 (KHTML, like Gecko) Silk\/3.21 Safari\/535.19 Silk-Accelerated=true",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Amazon",
-            "user_agent": "Mozilla\/5.0 (Linux; U; en-us; KFTHWI Build\/JDQ39) AppleWebKit\/535.19 (KHTML, like Gecko) Silk\/3.21 Safari\/535.19 Silk-Accelerated=true",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Amazon",
-            "user_agent": "Mozilla\/5.0 (Linux; U; en-us; KFJWI Build\/IMM76D) AppleWebKit\/535.19 (KHTML, like Gecko) Silk\/3.21 Safari\/535.19 Silk-Accelerated=true",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Amazon",
-            "user_agent": "Mozilla\/5.0 (Linux; U; en-us; KFSOWI Build\/JDQ39) AppleWebKit\/535.19 (KHTML, like Gecko) Silk\/3.21 Safari\/535.19 Silk-Accelerated=true",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Amazon",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.1; xx-xx; T720-WIFI Build\/ECLAIR) AppleWebKit\/530.17 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/530.17",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Amazon",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 5.1; KFARWI Build\/LMY47O) AppleWebKit\/537.36 (KHTML, like Gecko) Silk\/47.1.79 like Chrome\/47.0.2526.80 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Amazon",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.3; KFTHWI Build\/KTU84M) AppleWebKit\/537.36 (KHTML, like Gecko) Silk\/44.1.54 like Chrome\/44.0.2403.63 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Amazon",
-            "user_agent": "Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko) Silk\/44.1.54 like Chrome\/44.0.2403.63 Safari\/537.36",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Amazon",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 5.1.1; KFASWI Build\/LMY47O) AppleWebKit\/537.36 (KHTML, like Gecko) Silk\/48.2.2 like Chrome\/48.0.2564.95 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Amazon",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 5.1.1; KFFOWI Build\/LMY47O) AppleWebKit\/537.36 (KHTML, like Gecko) Silk\/46.1.66 like Chrome\/46.0.2490.80 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Amazon",
-            "user_agent": "Mozilla\/5.0 (Linux; U; en-us; KFAPWI Build\/JDQ39) AppleWebKit\/535.19 (KHTML, like Gecko) Silk\/3.13 Safari\/535.19 Silk-Accelerated=true",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Amazon",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 5.1.1; KFGIWI Build\/LVY48F) AppleWebKit\/537.36 (KHTML, like Gecko) Silk\/56.2.4 like Chrome\/56.0.2924.87 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Amazon",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.4.4; en-us; SD4930UR Build\/KTU84P) AppleWebKit\/537.36 (KHTML, like Gecko) Silk\/3.60 like Chrome\/37.0.2026.117 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
         },
         {
             "vendor": "HTC",
@@ -4840,6 +2228,1794 @@
             "tablet": false
         },
         {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.6; en-us; LG-VS410PP Build\/GRK39F) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2; en-us; LG-P509 Build\/FRF91) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1 MMS\/LG-Android-MMS-V1.0\/1.2",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2.2; pt-br; LG-P350f Build\/FRG83G) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1 MMS\/LG-Android-MMS-V1.0\/1.2",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.3; en-us; LG-P500 Build\/GRI40) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1 MMS\/LG-Android-MMS-V1.0\/1.2",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.3; en-us; LS670 Build\/GRI40) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; ru-ru; LG-E510 Build\/GRJ22) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1 MMS\/LG-Android-MMS-V1.0\/1.2",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; en-us; VS910 4G Build\/GRJ22) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; nl-nl; LG-P700 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build\/IML74K) AppleWebkit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; LG-F160S Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; nl-nl; LG-E610v\/V10f Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; LG-E612 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; LG-F180K Build\/JZO54K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; LG-V500 Build\/JDQ39B) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/31.0.1650.59 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; LG-LW770 Build\/IMM76I) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; LG-V510 Build\/KOT49H.L004) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; LG; LG E-900)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; LG; LG-C900)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; LG; LG-C900k)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; LG; LG-E900)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; LG; LG-E900; Orange)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; LG; LG-E900h)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; LG; LG-Optimus 7)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.0.1; ja-jp; L-06C Build\/HRI66) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.0; en-us; LG-V900 Build\/HRI39) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.4.2; en-gb; LG-V700 Build\/KOT49I.A1403851714) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/30.0.1599.103 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; LG-V500 Build\/KOT49I.V50020d) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/38.0.2125.102 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.4.2; en-us; LG-V410\/V41010d Build\/KOT49I.V41010d) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/30.0.1599.103 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 7.0; LG-M257 Build\/NRD90U) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/66.0.3359.126 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Dell",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 1.6; en-gb; Dell Streak Build\/Donut AppleWebKit\/528.5+ (KHTML, like Gecko) Version\/3.1.2 Mobile Safari\/ 525.20.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Dell",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.7; hd-us; Dell Venue Build\/GWK74; CyanogenMod-7.2.0) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Dell",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; DELL; Venue Pro)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Dell",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; Venue 8 3830 Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Dell",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; Venue 7 3730 Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/30.0.0.0 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Dell",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; Venue 7 HSPA+ Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/37.0.2062.117 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Dell",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; en-us; Venue 8 3830 Build\/JSS15Q) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Dell",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2; zh-cn; Dell Streak 10 Pro Build\/HTJ85B) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Dell",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 7.0.1; en-US; Dell Streak 7 Build\/FRF91) AppleWebKit\/51.0 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/51.0",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": 0,
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-au; TBLT10Q-32GB Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "AdvanDigital",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; E1C Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "AdvanDigital",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; id-id; T3C Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Ainol",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; en-us; Ainol Novo8 Advanced Build\/GRJ22) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Ainol",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; Novo10 Hero Build\/20121115) AppleWebKit\/535.19 (KHTML like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Ainol",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; es-es; novo9-Spark Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "AllFine",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; FINE7 GENIUS Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Amoi",
+            "user_agent": "Amoi 8512\/R18.0 NF-Browser\/3.3",
+            "mobile": true,
+            "tablet": false,
+            "model": "8512"
+        },
+        {
+            "vendor": "Arnova",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; fr-fr; AN9G2I Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "AudioSonic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-au; T-17B Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Blaupunkt",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; de-de; Endeavour 800NG Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Broncho",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2; es-es; Broncho N701 Build\/FRF91) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "bq",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; es-es; bq Livingstone 2 Build\/1.1.7 20121018-10:33) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "bq",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; es-es; bq Edison Build\/1.1.10-1015 20121230-18:00) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "bq",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; Maxwell Lite Build\/v1.0.0.ICS.maxwell.20120920) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "bq",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; zh-tw; bq Maxwell Plus Build\/1.0.0 20120913-10:39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "bq",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; Aquaris E10 Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/39.0.2171.93 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "bq",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 5.1; Aquaris M10 Build\/LMY47I) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/47.0.2526.83 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "bq",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0; Aquaris M10 FHD Build\/MRA58K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/58.0.3029.83 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "bq",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0; Aquaris M8 Build\/MRA58K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/60.0.3112.116 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "bq",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.4; Aquaris E5 Build\/KTU84P) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/57.0.2987.132 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "bq",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 5.0; Aquaris E5 HD Build\/LRX21M) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/55.0.2883.91 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "bq",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0; Aquaris_M4.5 Build\/MRA58K; wv) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/51.0.2704.81 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "bq",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0.1; Aquaris X5 Build\/MMB29M) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/52.0.2743.91 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "bq",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; Aquaris E4 Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/61.0.3163.98 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "bq",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 5.0.2; Aquaris M5 Build\/LRX22G) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/61.0.3163.98 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Captiva",
+            "user_agent": "Opera\/9.80 (X11; Linux zvav; U; de) Presto\/2.8.119 Version\/11.10 Mozilla\/5.0 (Linux; U; Android 4.1.1; de-de; CAPTIVA PAD 10.1 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Casio",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.3; en-us; C771 Build\/C771M120) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "ChangJia",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; pt-br; TPC97113 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ChangJia",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; TPC7102 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Celkon",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; en-us; Celkon CT 910+ Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Celkon",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-in; CT-1 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Celkon",
+            "user_agent": "CELKON.C64\/R2AE SEMC-Browser\/4.0.3 Profile\/MIDP-2.0 Configuration\/CLDC-1.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Celkon",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; Celkon A125 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Celkon",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.6; en-US; Celkon*A86 Build\/Celkon_A86) AppleWebKit\/528.5+ (KHTML, like Gecko) Version\/3.1.2 Mobile Safari\/525.20.1 UCBrowser\/8.7.0.315 Mobile",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Celkon",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; Celkon A.R 40 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Coby",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2; en-us; MID7010 Build\/FRF85B) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Coby",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; MID7048 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Coby",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; MID8042 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Concorde",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; hu-hu; ConCorde Tab T10 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Concorde",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; hu-hu; ConCorde tab PLAY Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Cresta",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; nl-nl; CRESTA.CTP888 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Cube",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; ru-ru; CUBE U9GT 2 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Danew",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; es-es; Dslide 700 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.3",
+                "Build": "IML74K",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            },
+            "model": "Dslide 700"
+        },
+        {
+            "vendor": "DanyTech",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Genius Tab Q4 Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/31.0.1650.59 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Digma",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; ru-ru; iDx10 3G Build\/ICS.b02ref.20120331) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "DPS",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; DPS Dream 9 Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ECS",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; it-it; TM105A Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.4",
+                "Build": "IMM76D",
+                "Webkit": "534.30"
+            }
+        },
+        {
+            "vendor": "Eboda",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; ro-ro; E-Boda Supreme Dual Core X190 Build\/JRO03C) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.1",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Eboda",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; ro-ro; E-Boda Essential A160 Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Eboda",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; E-Boda Supreme X80 Dual Core Build\/ICS.g12refM806A1YBD.20120925) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Eboda",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; ro-ro; E-boda essential smile Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Eboda",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; ro-ro; E-Boda Supreme X80 Dual Core Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Eboda",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; ro-ro; E-Boda Supreme XL200IPS Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Evolio",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; Evolio X7 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Evolio",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; ro-ro; ARIA_Mini_wifi Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Fly",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; ru-ru; Fly IQ440; Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Fly",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.6; ru-ru; FLY IQ256 Build\/GRK39F) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Fujitsu",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; ja-jp; F-10D Build\/V21R48A) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.3",
+                "Build": "V21R48A",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Fujitsu",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; ru-ru; M532 Build\/IML74K) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.3",
+                "Build": "IML74K",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "FX2",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; FX2 PAD7 RK Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Galapad",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; zh-tw; G1 Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.1",
+                "Webkit": "534.30",
+                "Safari": "4.0",
+                "Build": "JRO03C"
+            }
+        },
+        {
+            "vendor": "GoClever",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; el-gr; GOCLEVER TAB A103 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "GoClever",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; zh-tw; A7GOCLEVER Build\/GRJ22) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "GoClever",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; GOCLEVER TAB A104 Build\/IMM76D) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "GoClever",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; cs-cz; GOCLEVER TAB A93.2 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "GoClever",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; sk-sk; GOCLEVER TAB A971 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "GoClever",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; lv-lv; GOCLEVER TAB A972BK Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "GoClever",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; fr-fr; GOCLEVER TAB A104.2 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "GoClever",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; pt-pt; GOCLEVER TAB T76 Build\/MID) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "GU",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; vi-vn; TX-A1301 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.4",
+                "Build": "IMM76D",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "GU",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; da-dk; Q702 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.3",
+                "Build": "IML74K",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "HCL",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; U1 Build\/HCL ME Tablet U1) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "HCL",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; U1 Build\/HCL ME Tablet U1) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "HCL",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; Connect-3G-2.0 Build\/HCL) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/29.0.1547.72 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "HCL",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.3; pt-br; X1 Build\/HCL ME Tablet X1) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Hisense",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.4; F5281 Build\/KTU84Q) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/260.1985.135 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Hudl",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Hudl HT7S3 Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/30.0.1599.82 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Iconbit",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; NT-3702M Build\/JRO03C) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/29.0.1547.72 Safari\/537.36 OPR\/16.0.1212.65583",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Iconbit",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; ru-ru; NetTAB SPACE II Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "iJoy",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; fr-fr; Tablet Planet II-v3 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Intenso",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1.;de-de; INM8002KP Build\/JR003H) AppleWebKit\/534.30 (KHTML, like Gecko)Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.1.",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Intenso",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; TAB1004 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "INQ",
+            "user_agent": "INQ1\/R3.9.12 NF-Browser\/3.5",
+            "mobile": true,
+            "tablet": false,
+            "model": "INQ1"
+        },
+        {
+            "vendor": "Intex",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3; en-US; Cloud_X2 Build\/MocorDroid4.0.1) AppleWebKit\/528.5+ (KHTML, like Gecko) Version\/3.1.2 Mobile Safari\/525.20.1 UCBrowser\/9.2.0.419 Mobile",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Intex",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; Cloud Y2 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Intex",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-in; Cloud X5 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "IRU",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; ru-ru; M702pro Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "JXD",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; F3000 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Karbonn",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; ST10 Build\/JRO03C) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "KRAMER",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0; KT107 Build\/LMY47I) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/64.0.3282.137 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Kobo",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.0; en-us;) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1 (Kobo Touch)",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "2.0",
+                "Webkit": "533.1",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Megafon",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.5; ru-ru; MegaFon V9 Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Megafon",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; MT7A Build\/JRO03C) AppleWebKit\/537.31 (KHTML, like Gecko) Chrome\/26.0.1410.58 Safari\/537.31",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Mediacom",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0.1; M-MPI10C3G Build\/MMB29M) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/64.0.3282.137 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "MediaTek",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; fr-fr; MT8377 Build\/JRO03C) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30\/4.05d.1002.m7",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Micromax",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; Micromax A110 Build\/JRO03C) AppleWebKit\/537.22 (KHTML, like Gecko) Chrome\/25.0.1364.169 Mobile Safari\/537.22",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "Android": "4.1.1",
+                "Build": "JRO03C",
+                "Webkit": "537.22",
+                "Chrome": "25.0.1364.169"
+            }
+        },
+        {
+            "vendor": "Micromax",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0; xx-xx; Micromax P250(Funbook) Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Webkit": "534.30",
+                "Android": "4.0",
+                "Build": "IMM76D",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Modecom",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; pl-pl; FreeTAB 1014 IPS X4+ Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "MSI",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.5; el-gr; MSI Enjoy 10 Plus Build\/1.2) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Nabi",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2.1; en-us; NABI-A Build\/MASTER) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "NEC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; ja-jp; N-08D Build\/A5001911) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "NEC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android AAA; BBB; N-06D Build\/CCC) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Nexo",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; pl-pl; NEXO 3G Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30 ACHEETAHI\/2100050074",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Nibiru",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; zh-tw; Nibiru H1 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30 XiaoMi\/MiuiBrowser\/1.0",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nook",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2.1; en-us; NOOK BNRV200 Build\/ERD79 1.4.3) Apple WebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "2.2.1",
+                "Webkit": "533.1",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Nook",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; NOOK BNTV400 Build\/ICS) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.4",
+                "Build": "ICS",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Nook",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; BNTV600 Build\/IMM76L) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Safari\/537.36 Hughes-PFB\/CID5391275.AID1376709964",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.4",
+                "Build": "IMM76L",
+                "Webkit": "537.36",
+                "Chrome": "28.0.1500.94"
+            }
+        },
+        {
+            "vendor": "Oneplus",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; A0001 Build\/JLS36C) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Oneplus",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; xx-xx; A0001 Build\/JLS36C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Oneplus",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 7.1.1; ONEPLUS A5000 Build\/NMF26X; wv) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/60.0.3112.116 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Oneplus",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 8.1.0; ONEPLUS A5010 Build\/OPM1.171019.011; wv) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/66.0.3359.126 Mobile Safari\/537.36 [FB_IAB\/Orca-Android;FBAV\/164.0.0.24.95;]",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Odys",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; de-de; LOOX Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Odys",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; de-de; LOOX Plus Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Odys",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.X; de-de; XENO10 Build\/ODYS XENO 10) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Odys",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2.2; de-de; ODYS Space Build\/I700T_P7_T04_TSCL_FT_R_0_03_1010_110623) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Odys",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; de-de; ODYS-EVO Build\/ODYS-EVO) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Odys",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.X; de-de; Xelio 10 Pro Build\/ODYS_Xelio) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Odys",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; NEO_QUAD10 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Odys",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.X; de-de; Xelio10Pro Build\/ODYS_Xelio) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Odys",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.1; en-us; ODYS-Xpress Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Odys",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; de-de; XELIO7PHONETAB Build\/IMM76I) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Odys",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; XELIO10EXTREME Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Odys",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; de-de; XELIO Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30 Mobile UCBrowser\/3.2.1.441",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Odys",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; XELIOPT2 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Odys",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; nl-nl; ODYS-NOON Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "OverMax",
+            "user_agent": "OV-SteelCore(B) Mozilla\/5.0 (iPad; CPU OS 5_0_1 like Mac OS X) AppleWebKit\/534.46 (KHTML, like Gecko) Version\/5.1 Mobile\/9A405 Safari\/7534.48.3",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "OverMax",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; pl-pl; OV-SteelCore Build\/ICS.g08refem611.20121010) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "OverMax",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 7.0.99; Qualcore 1027 4G Build\/LMY47D) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/60.0.3112.116 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "YONESTablet",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; pl-pl; BC1077 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Pantech",
+            "user_agent": "PANTECH-C790\/JAUS08312009 Browser\/Obigo\/Q05A Profile\/MIDP-2.0 Configuration\/CLDC-1.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Pantech",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2.1; ko-kr; SKY IM-A600S Build\/FRG83) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Pantech",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.3; en-us; ADR8995 4G Build\/GRI40) AppleWebKit\/533.1 (KHTML like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Pantech",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2.1; en-us; PantechP4100 Build\/HTK75) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Philips",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; Philips W336 Build\/IMM76D) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.45 Mobile Safari\/537.36 OPR\/15.0.1162.59192",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Philips",
+            "user_agent": "Philips_T3500\/V1 Linux\/3.4.5 Android\/4.2.2 Release\/03.26.2013 Browser\/AppleWebKit534.30 Mobile Safari\/534.30 MBBMS\/2.2 System\/Android 4.2.2;",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Philips",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Philips W3568 Build\/Philips_W3568) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Philips",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; ru-ru; Philips W832 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Philips",
+            "user_agent": "Mozilla\/5.0 (Linux;U;Android 4.2.2;es-us;Philips S388 Build\/JDQ39) AppleWebkit\/534.30 (HTML,like Gecko) Version\/4.0 Mobile Safari\/534.30;",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Philips",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; Philips W536 Build\/IMM76D) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Philips",
+            "user_agent": "Mozilla\/5.0 (Linux;U;Android 4.2.2;es-us;Philips S308 Build\/JDQ39) AppleWebkit\/534.30 (HTML,like Gecko) Version\/4.0 Mobile Safari\/534.30;",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Philips",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; ru-ru; Philips-W8500 Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Philips",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; ru; Philips W8510 Build\/JDQ39) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 UCBrowser\/9.8.9.457 U3\/0.8.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Philips",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; ru-RU; Philips W3568 Build\/Philips W3568) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.1 Mobile Safari\/534.30;",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Philips",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Philips S388 Build\/JDQ39) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Philips",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; Build\/PI3100.00.00.24) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Philips",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; W732 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Philips",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.1; PI7100_93 Build\/PI7100.C.00.00.11) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/30.0.1599.92 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "PocketBook",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.7; en-ru; PocketBook A10 3G Build\/GRJ90) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "PointOfView",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; POV_TAB-PROTAB30-IPS10 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Polaroid",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 5.1.1; MID4X10 Build\/LMY47V) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/48.0.2564.95 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Praktica",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; TP750 3GGSM Build\/IMM76I) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/39.0.2171.93 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "PROSCAN",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; PLT8088 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.1",
+                "Build": "JRO03H",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "PyleAudio",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; PTBL92BC Build\/IMM76D) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/31.0.1650.59 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.4",
+                "Build": "IMM76D",
+                "Webkit": "537.36",
+                "Chrome": "31.0.1650.59"
+            }
+        },
+        {
+            "vendor": "RockChip",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2.1; hu-hu; RK2818, Build\/MASTER) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "RockChip",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android Android 2.1-RK2818-1.0.0; zh-cn; MD701 Build\/ECLAIR) AppleWebKit\/530.17 (KHTML like Gecko) Version\/4.0 Mobile Safari\/530.17",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "RossMoor",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.1; ru-ru; RM-790 Build\/JOP40D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "QMobile",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.6; en-us; A2 Build\/GRK39F) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "simvalley",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; de-de; SP-80 Build\/GRJ22) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Skk",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1; en-us; CYCLOPS Build\/F10) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Storex",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; eZee_Tab903 Build\/JRO03H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Safari\/537.36",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.1",
+                "Build": "JRO03H",
+                "Webkit": "537.36"
+            }
+        },
+        {
+            "vendor": "Storex",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; eZee'Tab785 Build\/JRO03C) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/31.0.1650.59 Safari\/537.36",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.1",
+                "Build": "JRO03C",
+                "Webkit": "537.36"
+            }
+        },
+        {
+            "vendor": "Storex",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; eZee'Tab971 Build\/IML74K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.3",
+                "Build": "IML74K",
+                "Webkit": "535.19"
+            }
+        },
+        {
+            "vendor": "Teclast",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; P98 3G\\xE5\\x85\\xAB\\xE6\\xA0\\xB8(A3HY) Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/30.0.0.0 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Teclast",
+            "user_agent": "QQ\\xe9\\x9f\\xb3\\xe4\\xb9\\x90HD 4.0.1 (iPad; iPhone OS 8.0; zh_CN)",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Teclast",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0; xx-xx; A15(E6C2) Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Teclast",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3; xx-xx; A10 Build\/GRJ22) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Teclast",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; Teclast A10T Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Teclast",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; zh-cn; Teclast P85(A9D3) Build\/IMM76D) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Teclast",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; A70H Build\/JDQ39) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 UCBrowser\/9.8.0.435 U3\/0.8.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Tecno",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; TECNO P9 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Tecno",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 5.1; TECNO DP8D Build\/LMY47D) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/49.0.2623.91 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Telstra",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.7; en-au; T-Hub2 Build\/TVA301TELBG3) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "texet",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; ru-ru; TM-7021 Build\/GB.m1ref.20120116) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "2.3.4",
+                "Webkit": "533.1",
+                "Safari": "4.0"
+            },
+            "model": "TM-7021"
+        },
+        {
+            "vendor": "Tolino",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; tolino tab 7 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.2.2",
+                "Build": "JDQ39",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Tolino",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; tolino tab 8.9 Build\/JDQ39) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.2.2",
+                "Build": "JDQ39",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Tolino",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; tolino tab 7 Build\/JDQ39) AppleWebkit\/537.36 (KHTML, like Gecko) Chrome\/31.0.1650.57 Safari\/537.36 OPR\/18.0.1290.67495",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Tolino",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; tolino tab 7 Build\/JDQ39) AppleWebkit\/537.36 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Toshiba",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; TOSHIBA; TSUNAGI)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Toshiba",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2; it-it; TOSHIBA_FOLIO_AND_A Build\/TOSHIBA_FOLIO_AND_A) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "2.2",
+                "Webkit": "533.1",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Trekstor",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; ST70408-1 Build\/JDQ39) AppleWebKit\/537.31 (KHTML, like Gecko) Chrome\/26.0.1410.58 Safari\/537.31",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.2.2",
+                "Build": "JDQ39",
+                "Webkit": "537.31",
+                "Chrome": "26.0.1410.58"
+            }
+        },
+        {
+            "vendor": "Trekstor",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; engb; Build\/IMM76D) AppleWebKit\/534.46 (KHTML, like Gecko) Version\/5.1 Mobile\/9A405 Safari\/7534.48.3 SurfTab_7.0",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Trekstor",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; VT10416-2 Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Trekstor",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; de-de; ST10216-2A Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30;SurfTab_10.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Tsmine",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; TM1088 Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/66.0.3359.126 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Ubislate",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; UBISLATE7C+ Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "WeVool",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 5.0; WVT101 Build\/LRX21M) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/66.0.3359.126 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Visture",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-gb; V97 HD Build\/LR-97JC) Apple WebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Visture",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; Visture V4 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Visture",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; ru-ru; Visture V4 HD Build\/Visture V4 HD) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Visture",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; es-es; Visture V5 HD Build\/Visture V5 HD) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Visture",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; ru-ru; Visture V10 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Versus",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; VS-TOUCHPAD 9 Build\/IMM76D) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Versus",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-gb; Versus Touchpad 9.7 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Versus",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-gb; CnM-TOUCHPAD7 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30 BMID\/E67A45B1AB",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Versus",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; CnM TouchPad 7DC Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30 TwonkyBeamBrowser\/3.3.5-95 (Android 4.1.1; rockchip CnM TouchPad 7DC Build\/meizhi_V2.80.wifi8723.20121225.b11c800)",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Versus",
+            "user_agent": "OneBrowser\/3.5\/Mozilla\/5.0 (Linux; U; Android 4.0.4; en-gb; TOUCHPAD 7 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Versus",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; TOUCHTAB Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.1",
+                "Build": "JRO03H",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Viewsonic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; de-de; ViewPad 10e Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Viewsonic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2; it-it; ViewPad7 Build\/FRF91) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Viewsonic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2.1; en-ca; ViewSonic VB733 Build\/FRG83) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Viewsonic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2; en-gb; ViewPad7X Build\/HTJ85B) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Viewsonic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2; pt-br; ViewPad 10S Build\/FRF91) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Viewsonic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; VB100a Pro Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Vonino",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; Sirius_Evo_QS Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Vonino",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; Q8 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Wolder",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4; miTab LIVE Build\/KVT49L) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/30.0.0.0 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Wolder",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; pt-pt; miTab FUNK Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Wolfgang",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.1; nl-nl; AT-AS45q2 Build\/JOP40D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Xoro",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; PAD 9720QR Build\/PAD 9719QR) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Xoro",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; PAD720 Build\/JDQ39) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ZTE",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; V8200plus Build\/IMM76I) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/33.0.1750.166 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Zync",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.3; en-us ; Z909 Build\/GRI40) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1\/UCBrowser\/8.4.1.204\/145\/444",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "AOC",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; MW0922 Build\/IMM76D) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/42.0.2311.111 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "AOC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; es-us; MW0831Plus Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.1-update1; bg-bg; Ideos S7 Build\/ERE27) AppleWebKit\/525.10+ (KHTML, like Gecko) Version\/3.0.4 Mobile Safari\/523.12.2",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.1; en-us; Ideos S7 Build\/ERE27) AppleWebKit\/525.10+ (KHTML, like Gecko) Version\/3.0.4 Mobile Safari\/523.12.2",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.6; lt-lt; U8660 Build\/HuaweiU8660) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.7; ru-ru; HUAWEI-U8850 Build\/HuaweiU8850) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2; pl-pl; MediaPad Build\/HuaweiMediaPad) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2; nl-nl; HUAWEI MediaPad Build\/HuaweiMediaPad) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "HUAWEI_T8951_TD\/1.0 Android\/4.0.4 (Linux; U; Android 4.0.4; zh-cn) Release\/05.31.2012 Browser\/WAP2.0 (AppleWebKit\/534.30) Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; ar-eg; MediaPad 7 Youth Build\/HuaweiMediaPad) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; zh-cn; HW-HUAWEI_C8815\/C8815V100R001C541B135; 540*960; CTC\/2.0) AppleWebKit\/534.30 (KHTML, like Gecko) Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; zh-cn; HW-HUAWEI_C8813D\/C8813DV100R001C92B172; 480*854; CTC\/2.0) AppleWebKit\/534.30 (KHTML, like Gecko) Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; zh-cn; HW-HUAWEI_Y300C\/Y300CV100R001C92B168; 480*800; CTC\/2.0) AppleWebKit\/534.30 (KHTML, like Gecko) Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; id-id; HUAWEI Y330-U11 Build\/HuaweiY330-U11) AppleWebKit\/537.16 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/537.16 Chrome\/33.0.0.0",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 5.1.1; HUAWEI M2-A01L Build\/HUAWEIM2-A01L) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/59.0.3071.125 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0; HUAWEI GRA-L09 Build\/HUAWEIGRA-L09) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/63.0.3239.111 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 7.0; FRD-L09 Build\/HUAWEIFRD-L09) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/63.0.3239.111 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 8.0; DUK-AL20 Build\/HUAWEIDUK-AL20; wv) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/57.0.2987.132 MQQBrowser\/6.2 TBS\/044054 Mobile Safari\/537.36 V1_AND_SQ_7.5.8_818_YYB_D QQ\/7.5.8.3490 NetType\/WIFI WebP\/0.3.0 Pixe",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 7.0; BAH-L09 Build\/HUAWEIBAH-L09) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/66.0.3359.126 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 7.0; BAH-W09 Build\/HUAWEIBAH-W09) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/62.0.3202.84 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 7.0; WAS-LX3 Build\/HUAWEIWAS-LX3; wv) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/63.0.3239.111 Mobile Safari\/537.36 [FB_IAB\/Orca-Android;FBAV\/162.0.0.19.90;]",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 8.1.0; Nexus 6P Build\/OPM3.171019.014) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/64.0.3282.137 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
             "vendor": "Alcatel",
             "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.7; en-in; MB525 Build\/GWK74; CyanogenMod-7.2.0) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
             "mobile": true,
@@ -5124,1080 +4300,6 @@
             "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; ALCATEL ONE TOUCH 8020X Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.2 Mobile Safari\/534.30",
             "mobile": true,
             "tablet": false
-        },
-        {
-            "vendor": "Huwaei",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.1-update1; bg-bg; Ideos S7 Build\/ERE27) AppleWebKit\/525.10+ (KHTML, like Gecko) Version\/3.0.4 Mobile Safari\/523.12.2",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Huwaei",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.1; en-us; Ideos S7 Build\/ERE27) AppleWebKit\/525.10+ (KHTML, like Gecko) Version\/3.0.4 Mobile Safari\/523.12.2",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Huwaei",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.6; lt-lt; U8660 Build\/HuaweiU8660) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Huwaei",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.7; ru-ru; HUAWEI-U8850 Build\/HuaweiU8850) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Huwaei",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2; pl-pl; MediaPad Build\/HuaweiMediaPad) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Huwaei",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2; nl-nl; HUAWEI MediaPad Build\/HuaweiMediaPad) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Huwaei",
-            "user_agent": "HUAWEI_T8951_TD\/1.0 Android\/4.0.4 (Linux; U; Android 4.0.4; zh-cn) Release\/05.31.2012 Browser\/WAP2.0 (AppleWebKit\/534.30) Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Huwaei",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; ar-eg; MediaPad 7 Youth Build\/HuaweiMediaPad) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Huwaei",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; zh-cn; HW-HUAWEI_C8815\/C8815V100R001C541B135; 540*960; CTC\/2.0) AppleWebKit\/534.30 (KHTML, like Gecko) Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Huwaei",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; zh-cn; HW-HUAWEI_C8813D\/C8813DV100R001C92B172; 480*854; CTC\/2.0) AppleWebKit\/534.30 (KHTML, like Gecko) Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Huwaei",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; zh-cn; HW-HUAWEI_Y300C\/Y300CV100R001C92B168; 480*800; CTC\/2.0) AppleWebKit\/534.30 (KHTML, like Gecko) Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Huwaei",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; id-id; HUAWEI Y330-U11 Build\/HuaweiY330-U11) AppleWebKit\/537.16 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/537.16 Chrome\/33.0.0.0",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Huwaei",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 5.1.1; HUAWEI M2-A01L Build\/HUAWEIM2-A01L) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/59.0.3071.125 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Huwaei",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0; HUAWEI GRA-L09 Build\/HUAWEIGRA-L09) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/63.0.3239.111 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Huwaei",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 7.0; FRD-L09 Build\/HUAWEIFRD-L09) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/63.0.3239.111 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Huwaei",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 8.0; DUK-AL20 Build\/HUAWEIDUK-AL20; wv) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/57.0.2987.132 MQQBrowser\/6.2 TBS\/044054 Mobile Safari\/537.36 V1_AND_SQ_7.5.8_818_YYB_D QQ\/7.5.8.3490 NetType\/WIFI WebP\/0.3.0 Pixe",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Huwaei",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 7.0; BAH-L09 Build\/HUAWEIBAH-L09) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/66.0.3359.126 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Huwaei",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 7.0; BAH-W09 Build\/HUAWEIBAH-W09) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/62.0.3202.84 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Huwaei",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 7.0; WAS-LX3 Build\/HUAWEIWAS-LX3; wv) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/63.0.3239.111 Mobile Safari\/537.36 [FB_IAB\/Orca-Android;FBAV\/162.0.0.19.90;]",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Huwaei",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 8.1.0; Nexus 6P Build\/OPM3.171019.014) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/64.0.3282.137 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "MOT-W510\/08.11.05R MIB\/BER2.2 Profile\/MIDP-2.0 Configuration\/CLDC-1.1 EGE\/1.0 UP.Link\/6.3.0.0.0",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2.2; zh-cn; ME722 Build\/MLS2GC_2.6.0) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; en-us; DROIDX Build\/4.5.1_57_DX8-51) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.5; en-us; MB855 Build\/4.5.1A-1_SUN-254_13) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.5; es-us; MB526 Build\/4.5.2-51_DFL-50) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.6; en-ca; MB860 Build\/4.5.2A-51_OLL-17.8) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.7; en-us; MOT-XT535 Build\/V1.540) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.7; ko-kr; A853 Build\/SHOLS_U2_05.26.3; CyanogenMod-7.1.2) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.0; en-us; Xoom Build\/HRI39) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.1; en-us; Xoom Build\/HMJ25) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; DROID RAZR 4G Build\/6.7.2-180_DHD-16_M4-31) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; Xoom Build\/IMM76L) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; pt-br; XT687 Build\/V2.27D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false,
-            "version": {
-                "Android": "4.0.4",
-                "Webkit": "534.30",
-                "Safari": "4.0"
-            },
-            "model": "XT687"
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; es-es; MOT-XT910 Build\/6.7.2-180_SPU-19-TA-11.6) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; XT910 Build\/9.8.2O-124_SPUL-17) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; XT915 Build\/2_32A_2031) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; XT919 Build\/2_290_2017) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.64 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; XT925 Build\/9.8.2Q-50-XT925_VQLM-20) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.90 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; XT907 Build\/9.8.1Q-66) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.90 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; XT901 Build\/9.8.2Q-50_SLS-13) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; DROID BIONIC Build\/9.8.2O-72_VZW-22) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; XT1022 Build\/KXC20.82-14) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.4.4; en-in; XT1022 Build\/KXC21.5-40) AppleWebKit\/537.16 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/537.16",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; XT1025 Build\/KXC20.82-13) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; XT1052 Build\/KLA20.16-2.16.2) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-gb; XT1052 Build\/13.9.0Q2.X_83) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; XT1053 Build\/13.9.0Q2.X_61) AppleWebKit\/537.31 (KHTML, like Gecko) Chrome\/26.0.1410.58 Mobile Safari\/537.31",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; XT1053 Build\/13.9.0Q2.X_55) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; XT1056 Build\/13.9.0Q2.X-116-MX-17-6-2) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.64 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; XT1031 Build\/KXB20.9-1.10-1.18-1.1) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.4; XT1032 Build\/KXB21.14-L1.40) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.4.2; de-de; XT1032 Build\/KLB20.9-1.10-1.24-1.1) AppleWebKit\/537.16 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/537.16",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; XT1034 Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; en-us; XT1034 Build\/14.10.0Q3.X-84-16) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; XT1035 Build\/14.10.0Q3.X-23) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/29.0.1547.59 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.3; XT1039 Build\/KXB21.14-L1.31) AppleWebKit\/537.36 (KHTML like Gecko) Chrome\/35.0.1916.141 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; en-us; XT919 Build\/2_290_2002) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; XT919 Build\/2_290_2004) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.90 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; en-us; XT920 Build\/2_290_2014) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; XT920 Build\/2_310_2014) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; XT905 Build\/7.7.1Q_GCIRD-16) AppleWebKit\/537.22 (KHTML, like Gecko) Chrome\/25.0.1364.169 Mobile Safari\/537.22",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; XT908 Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/30.0.0.0 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; XT897 Build\/7.7.1Q-6_SPR-ASANTI_LE-18) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 5.0.2; XT1032 Build\/LXB22.46-28.1) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/43.0.2357.92 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 5.1.1; Moto E Build\/LMY47V) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/39.0.0.0 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.4; XT1021 Build\/KTU84Q) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/33.0.0.0 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 5.0.2; XT1068 Build\/LXB22.46-28) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/54.0.2840.85 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Motorola",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0; XT1092 Build\/MPE24.49-18) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/54.0.2840.85 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2486.0 Safari\/537.36 Edge\/13.10586",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident\/6.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0)",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "IE": "10.0",
-                "Windows NT": "6.2",
-                "Trident": "6.0"
-            }
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident\/6.0)",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident\/6.0; Touch)",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident\/6.0; Touch; ARMBJS)",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Win64; x64; Trident\/6.0; Touch; MASMJS)",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Windows NT 6.2; WOW64; rv:25.0) Gecko\/20130626 Firefox\/25.0",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Windows NT 6.2; WOW64; rv:22.0) Gecko\/20100101 Firefox\/22.0",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Win64; x64; Trident\/6.0; MDDCJS)",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident\/6.0; MDDCJS)",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Windows NT 6.2; WOW64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.52 Safari\/537.36 OPR\/15.0.1147.130",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Windows NT 6.2; WOW64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.116 Safari\/537.36",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Win64; x64; Trident\/6.0; Touch; MDDCJS; WebView\/1.0)",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident\/6.0; IEMobile\/10.0; ARM; Touch; Microsoft; Lumia 640 XL LTE)",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident\/6.0; IEMobile\/10.0; ARM; Touch; NOKIA; Lumia 520)",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident\/6.0; IEMobile\/10.0; ARM; Touch; NOKIA; Lumia 620)",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident\/6.0; IEMobile\/10.0; ARM; Touch; NOKIA; Lumia 822)",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Lumia 800)",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; Microsoft; Lumia 430 Dual SIM) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; Microsoft; Lumia 435) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; Microsoft; Lumia 532) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; Microsoft; Lumia 535) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; Microsoft; Lumia 535) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537 BMID\/E679DAAB6F",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; Microsoft; Lumia 640 LTE) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 1520) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 520) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 520) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537 UCBrowser\/4.2.1.541 Mobile",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 520; Vodafone) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 530) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 620) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 625) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 630 Dual SIM) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 630) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 635) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 635; Vodafone) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 735) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 820; Vodafone) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 830) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 925) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 930) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Windows NT 6.2; ARM; Trident\/7.0; Touch; rv:11.0; WPDesktop; Lumia 635) like Gecko",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 550) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2486.0 Mobile Safari\/537.36 Edge\/13.10586",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 640 Dual SIM) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2486.0 Mobile Safari\/537.36 Edge\/13.10586",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 950 XL) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2486.0 Mobile Safari\/537.36 Edge\/13.10586",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 950) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2486.0 Mobile Safari\/537.36 Edge\/13.10586",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Windows Phone 10.0; Android 4.2.1; NOKIA; Lumia 625) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2486.0 Mobile Safari\/537.36 Edge\/13.10586",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Windows Phone 10.0; Android 4.2.1; NOKIA; Lumia 635) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2486.0 Mobile Safari\/537.36 Edge\/13.10586",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Windows Phone 10.0; Android 4.2.1; NOKIA; Lumia 830) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2486.0 Mobile Safari\/537.36 Edge\/14.14295",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Windows Phone 10.0; Android 4.2.1; NOKIA; Lumia 930) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2486.0 Mobile Safari\/537.36 Edge\/14.14295",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Windows Phone 8.1; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 530 Dual SIM) like Gecko",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Windows NT 10.0; ARM; Lumia 950 XL) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2486.0 Safari\/537.36 Edge\/13.10586",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Windows NT 10.0; ARM; Lumia 950) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2486.0 Safari\/537.36 Edge\/13.10586",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Windows NT 10.0; ARM; Lumia 930) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2486.0 Safari\/537.36 Edge\/13.10586",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Microsoft",
-            "user_agent": "Mozilla\/5.0 (Windows NT 10.0; ARM; Lumia 730 Dual SIM) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2486.0 Safari\/537.36 Edge\/13.10586",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; es-es; IdeaTab_A1107 Build\/MR1) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; IdeaTab A2107A-H Build\/IML74K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.90 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-au; ThinkPad Tablet Build\/ThinkPadTablet_A400_03) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "UCWEB\/2.0 (Linux; U; Opera Mini\/7.1.32052\/30.3697; en-US; IdeaTabA1000-G) U2\/1.0.0 UCBrowser\/9.2.0.419 Mobile",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; IdeaTabA1000-F Build\/JZO54K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.1; Lenovo A3000-H Build\/JOP40D) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.117 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; IdeaTab A3000-F Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Safari\/537.360",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1; zh-cn; Lenovo-A3000-H\/S100) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.1 Mobile Safari\/534.300",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; es-us; IdeaTab A3000-F Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; IdeaTab A2107A-H Build\/IML74K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; de-de; IdeaTab A2107A-H Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; es-es; IdeaTabA2109A Build\/JRO03R) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; nl-nl; IdeaTabA2109A Build\/JRO03R) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; es-es; IdeaTab_A1107 Build\/MR1) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.300",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; IdeaTab S6000-H Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.138 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-gb; IdeaTab S6000-F Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Lenovo B8000-F Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2;it-it; Lenovo B8000-F\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.2.2 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; it-it; Lenovo B6000-F\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.2.2 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Lenovo B6000-F Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; IdeaPadA10 Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/33.0.1750.166 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; Ideapad K1 Build\/JZO54K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.7; de-de; IdeaPad A1 Build\/GRK393; CyanogenMod-7) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; Lenovo B8080-H Build\/JLS36C) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; hu-hu; Lenovo A3500-FL Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; Lenovo A7600-F Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; Lenovo A5500-F Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/36.0.1985.131 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Lenovo A390 Linux\/3.0.13 Android\/4.4.2 Release\/04.03.2013 Browser\/AppleWebKit534.30 Profile\/MIDP-2.0 Configuration\/CLDC-1.1 Mobile Safari\/534.30 Android 4.0.1;",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; Lenovo TAB 2 A7-30F Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/45.0.2454.84 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; Lenovo A319 Build\/MocorDroid4.4.2) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/48.0.2564.95 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 5.1; Lenovo YT3-X90L Build\/LMY47I) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/49.0.2623.105 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0.1; Lenovo TB-X103F Build\/LenovoTB-X103F) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/56.0.2924.87 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 7.1.1; Lenovo TB-X304F Build\/NMF26F) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/60.0.3112.116 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0.1; Lenovo TB-8703F Build\/MMB29M) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/56.0.2924.87 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 7.0; Lenovo P2a42 Build\/NRD90N) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/57.0.2987.132 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0.1; Lenovo P2a42 Build\/MMB29M) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/58.0.3029.83 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 7.1.1; Lenovo TB-X304L Build\/NMF26F) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/56.0.2924.87 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lenovo",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; Tab2A7-10F Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/30.0.0.0 Safari\/537.36 ACHEETAHI\/1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Acer",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2.1; en-us; A100 Build\/HTK55D) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Acer",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1; en-us; A110 Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Acer",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; de-de; A200 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.0.3",
-                "Webkit": "534.30",
-                "Safari": "4.0",
-                "Build": "IML74K"
-            },
-            "model": "A200"
-        },
-        {
-            "vendor": "Acer",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; A500 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Acer",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; A501 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Acer",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; A701 Build\/JRO03H) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Acer",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; B1-A71 Build\/JZO54K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Acer",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; B1-710 Build\/JZO54K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/29.0.1547.72 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Acer",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; A1-810 Build\/JDQ39) AppleWebKit\/537.31 (KHTML, like Gecko) Chrome\/26.0.1410.58 Safari\/537.31",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Acer",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; nl-nl; A1-810 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Acer",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Acer; Allegro)",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Acer",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; A3-A10 Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Safari\/537.36",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.2.2",
-                "Build": "JDQ39",
-                "Webkit": "537.36",
-                "Chrome": "32.0.1700.99"
-            }
-        },
-        {
-            "vendor": "Acer",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; A1-811 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Acer",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; A1-830 Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Acer",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; A3-A11 Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
         },
         {
             "vendor": "Samsung",
@@ -7327,1144 +5429,6 @@
             "tablet": false
         },
         {
-            "vendor": "BlackBerry",
-            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9300; en) AppleWebKit\/534.8+ (KHTML, like Gecko) Version\/6.0.0.546 Mobile Safari\/534.8+",
-            "mobile": true,
-            "tablet": false,
-            "version": {
-                "Webkit": "534.8+",
-                "BlackBerry": "6.0.0.546"
-            },
-            "model": "BlackBerry 9300"
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9360; en-US) AppleWebKit\/534.11+ (KHTML, like Gecko) Version\/7.0.0.400 Mobile Safari\/534.11+",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9700; he) AppleWebKit\/534.8+ (KHTML, like Gecko) Version\/6.0.0.723 Mobile Safari\/534.8+",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9700; en-US) AppleWebKit\/534.8  (KHTML, like Gecko) Version\/6.0.0.448 Mobile Safari\/534.8",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9790; en-GB) AppleWebKit\/534.11+ (KHTML, like Gecko) Version\/7.1.0.714 Mobile Safari\/534.11+",
-            "mobile": true,
-            "tablet": false,
-            "version": {
-                "Webkit": "534.11+",
-                "BlackBerry": "7.1.0.714"
-            },
-            "model": "BlackBerry 9790"
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "Opera\/9.80 (BlackBerry; Opera Mini\/7.0.29990\/28.2504; U; en) Presto\/2.8.119 Version\/11.10",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9981; en-GB) AppleWebKit\/534.11+ (KHTML, like Gecko) Version\/7.1.0.342 Mobile Safari\/534.11+",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9800; en-GB) AppleWebKit\/534.8+ (KHTML, like Gecko) Version\/6.0.0.546 Mobile Safari\/534.8+",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9780; es) AppleWebKit\/534.8  (KHTML, like Gecko) Version\/6.0.0.480 Mobile Safari\/534.8",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9810; en-US) AppleWebKit\/534.11  (KHTML, like Gecko) Version\/7.0.0.583 Mobile Safari\/534.11",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9860; es) AppleWebKit\/534.11+ (KHTML, like Gecko) Version\/7.0.0.576 Mobile Safari\/534.11+",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9900; en-US) AppleWebKit\/534.11  (KHTML, like Gecko) Version\/7.1.0.523 Mobile Safari\/534.11",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "BlackBerry8520\/5.0.0.592 Profile\/MIDP-2.1 Configuration\/CLDC-1.1 VendorID\/136",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "BlackBerry8520\/5.0.0.1067 Profile\/MIDP-2.1 Configuration\/CLDC-1.1 VendorID\/603",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "BlackBerry8520\/5.0.0.1036 Profile\/MIDP-2.1 Configuration\/CLDC-1.1 VendorID\/611",
-            "mobile": true,
-            "tablet": false,
-            "version": {
-                "BlackBerry": "5.0.0.1036",
-                "VendorID": "611"
-            },
-            "model": "BlackBerry8520"
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9220; en) AppleWebKit\/534.11+ (KHTML, like Gecko) Version\/7.1.0.337 Mobile Safari\/534.11+",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "Mozilla\/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit\/536.2+ (KHTML, like Gecko) Version\/7.2.1.0 Safari\/536.2+",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "Mozilla\/5.0 (BB10; Touch) AppleWebKit\/537.1+ (KHTML, like Gecko) Version\/10.0.0.1337 Mobile Safari\/537.1+",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "Mozilla\/5.0 (BB10; Touch) AppleWebKit\/537.10+ (KHTML, like Gecko) Version\/10.0.9.2372 Mobile Safari\/537.10+",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "Mozilla\/5.0 (BB10; Touch) \/537.10+ (KHTML, like Gecko) Version\/10.0.9.2372 Mobile Safari\/537.10+",
-            "mobile": true,
-            "tablet": false,
-            "version": {
-                "BlackBerry": "10.0.9.2372"
-            }
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2.1; en-us; Transformer TF101 Build\/HTK75) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "3.2.1",
-                "Webkit": "534.13",
-                "Safari": "4.0"
-            },
-            "model": "Transformer TF101"
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; de-de; A200 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.0.3",
-                "Webkit": "534.30",
-                "Safari": "4.0"
-            },
-            "model": "A200"
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; A500 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.0.3",
-                "Webkit": "534.30",
-                "Safari": "4.0"
-            },
-            "model": "A500"
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; A501 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.0.3",
-                "Webkit": "534.30",
-                "Safari": "4.0"
-            },
-            "model": "A501"
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; Transformer Build\/JRO03L) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.1.1",
-                "Webkit": "535.19",
-                "Chrome": "18.0.1025.166"
-            },
-            "model": "Transformer"
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; ASUS Transformer Pad TF300T Build\/JRO03C) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.1.1",
-                "Webkit": "535.19",
-                "Chrome": "18.0.1025.166"
-            },
-            "model": "Transformer Pad TF300T"
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; fr-fr; Transformer Build\/JZO54K; CyanogenMod-10) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.1.2",
-                "Webkit": "534.30",
-                "Safari": "4.0",
-                "Build": "JZO54K"
-            },
-            "model": "Transformer"
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; B1-A71 Build\/JZO54K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.1.2",
-                "Webkit": "535.19",
-                "Chrome": "18.0.1025.166"
-            },
-            "model": "B1-A71"
-        },
-        {
-            "vendor": "BlackBerry",
-            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Acer; Allegro)",
-            "mobile": true,
-            "tablet": false,
-            "version": {
-                "Windows Phone OS": "7.5",
-                "Trident": "5.0",
-                "IE": "9.0"
-            },
-            "model": "Allegro"
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "SonyEricssonK800i\/R1AA Browser\/NetFront\/3.3 Profile\/MIDP-2.0 Configuration\/CLDC-1.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.1-update1; es-ar; SonyEricssonE15a Build\/2.0.1.A.0.47) AppleWebKit\/530.17 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/530.17",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.1-update1; pt-br; SonyEricssonU20a Build\/2.1.1.A.0.6) AppleWebKit\/530.17 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/530.17",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.3; en-au; SonyEricssonX10i Build\/3.0.1.G.0.75) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; ru-ru; SonyEricssonST18i Build\/4.0.2.A.0.62) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; hr-hr; SonyEricssonST15i Build\/4.0.2.A.0.62) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; sk-sk; SonyEricssonLT15i Build\/4.0.2.A.0.62) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.7; th-th; SonyEricssonST27i Build\/6.0.B.3.184) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.7; de-de; SonyEricssonST25i Build\/6.0.B.3.184) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; pt-br; Xperia Tablet S Build\/TID0092) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.0.3",
-                "Build": "TID0092",
-                "Webkit": "534.30",
-                "Safari": "4.0"
-            }
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; LT18i Build\/4.1.A.0.562) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; Sony Tablet S Build\/TISU0R0110) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; es-es; Sony Tablet S Build\/TISU0143) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-gb; SonyEricssonLT18i Build\/4.1.B.0.587) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; fr-ch; SonyEricssonSK17i Build\/4.1.B.0.587) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; SonyEricssonLT26i Build\/6.1.A.2.45) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; LT22i Build\/6.1.B.0.544) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; vi-vn; SonyEricssonLT22i Build\/6.1.B.0.544) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; ST23i Build\/11.0.A.5.5) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; ST23i Build\/11.0.A.2.10) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; LT28h Build\/6.1.E.3.7) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; SGPT13 Build\/TJDS0170) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; ja-jp; SonySO-03E Build\/10.1.E.0.265) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.1.2",
-                "Build": "10.1.E.0.265",
-                "Webkit": "534.30",
-                "Safari": "4.0"
-            }
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; LT26w Build\/6.2.B.1.96) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/29.0.1547.72 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; SGP321 Build\/10.3.1.A.0.33) AppleWebKit\/537.31 (KHTML, like Gecko) Chrome\/26.0.1410.58 Safari\/537.31",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Android": "4.2.2",
-                "Build": "10.3.1.A.0.33",
-                "Webkit": "537.31",
-                "Chrome": "26.0.1410.58"
-            }
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; C5303 Build\/12.1.A.1.205) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/36.0.1985.135 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; zh-cn; XL39h Build\/14.2.A.1.136) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; sv-se; C5503 Build\/10.1.1.A.1.273) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; en-us; C5502 Build\/10.1.1.A.1.310) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; zh-cn; SonyL39t Build\/14.1.M.0.202) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; zh-cn; L39u Build\/14.1.n.0.63) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; zh-tw; M35c Build\/12.0.B.5.37) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; M35c Build\/12.0.B.2.42) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.90 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; zh-CN; M35t Build\/12.0.C.2.42) AppleWebKit\/534.31 (KHTML, like Gecko) UCBrowser\/9.3.2.349 U3\/0.8.0 Mobile Safari\/534.31",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; D6502 Build\/17.1.A.2.69) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/30.0.0.0 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; D6503 Build\/17.1.A.0.504) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; D6543 Build\/17.1.A.2.55) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; D2004 Build\/20.0.A.0.29) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; en-gb; D2005 Build\/20.0.A.1.12) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; D2104 Build\/20.0.B.0.84) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; D2105 Build\/20.0.B.0.74) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/33.0.1750.170 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; pt-br; D2114 Build\/20.0.B.0.85) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; D2302 Build\/18.0.B.1.23) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.138 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; zh-cn; S50h Build\/18.0.b.1.23) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 UCBrowser\/9.6.3.413 U3\/0.8.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; D2303 Build\/18.0.C.1.13) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.138 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; D2305 Build\/18.0.A.1.30) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.138 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; D2306 Build\/18.0.C.1.7) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/33.0.1750.136 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; D5303 Build\/19.0.1.A.0.207) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; D5306 Build\/19.1.A.0.264) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/33.0.1750.136 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; zh-CN; XM50h Build\/19.0.D.0.269) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 UCBrowser\/9.7.6.428 U3\/0.8.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; zh-cn; XM50t Build\/19.0.C.2.59) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; D5322 Build\/19.0.D.0.253) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.131",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; zh-cn; M51w Build\/14.2.A.1.146) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; M51w Build\/14.2.A.1.146) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/33.0.1750.136 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.1; D5102 Build\/18.2.A.0.9) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.1; D5103 Build\/18.1.A.0.11) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/30.0.1599.92 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.1; D5106 Build\/18.1.A.0.11) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; en-gb; C6902 Build\/14.2.A.1.136) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30 GSA\/3.2.17.1009776.arm",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; es-es; C6943 Build\/14.1.G.2.257) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; C6943 Build\/14.3.A.0.681) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; SGP412 Build\/14.1.B.3.320) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1; en-us; SonySGP321 Build\/10.2.C.0.143) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; SGP351 Build\/10.1.1.A.1.307) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; SGP341 Build\/10.4.B.0.569) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; SGP511 Build\/17.1.A.2.36) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.122 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; SGP512 Build\/17.1.A.2.36) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.122 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; fr-ch; SGP311 Build\/10.1.C.0.344) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; en-us; SGP312 Build\/10.1.C.0.344) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.4.2; de-de; SGP521 Build\/17.1.A.2.69) AppleWebKit\/537.16 (KHTML, like Gecko) Version\/4.0 Safari\/537.16",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.4.2; zh-cn; SGP541 Build\/17.1.A.2.36) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; SGP551 Build\/17.1.A.2.72) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "SonyEricssonU5i\/R2CA; Mozilla\/5.0 (SymbianOS\/9.4; U; Series60\/5.0 Profile\/MIDP-2.1 Configuration\/CLDC-1.1) AppleWebKit\/525 (KHTML, like Gecko) Version\/3.0 Safari\/525",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "SonyEricssonU5i\/R2AA; Mozilla\/5.0 (SymbianOS\/9.4; U; Series60\/5.0 Profile\/MIDP-2.1 Configuration\/CLDC-1.1) AppleWebKit\/525 (KHTML, like Gecko) Version\/3.0 Safari\/525",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/4.0 (PDA; PalmOS\/sony\/model prmr\/Revision:1.1.54 (en)) NetFront\/3.0",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Opera\/9.80 (Linux mips; U; InettvBrowser\/2.2 (00014A;SonyDTV115;0002;0100) KDL40EX720; CC\/BEL; en) Presto\/2.7.61 Version\/11.00",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Opera\/9.80 (Linux armv7l; HbbTV\/1.1.1 (; Sony; KDL32W650A; PKG3.211EUA; 2013;); ) Presto\/2.12.362 Version\/12.11",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; es-ve; SonyST21a2 Build\/11.0.A.6.5) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; D2533 Build\/19.2.A.0.391) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/30.0.0.0 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.4; Xperia SP Build\/KTU84Q) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/41.0.2272.96 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla \/ 5.0 (Linux; Android 5.0.2; SOT31 Build \/ 28.0.D.6.71) AppleWebKit \/ 537.36 (KHTML, like Gecko) Chrome \/ 39.0.2171.93 Safari \/ 537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 5.1.1; E5823 Build\/32.0.A.4.11) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2490.76 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Sony",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 5.0; E2303 Build\/26.1.A.3.111) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/66.0.3359.126 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Apple",
-            "user_agent": "iTunes\/9.1.1",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Apple",
-            "user_agent": "iTunes\/11.0.2 (Windows; Microsoft Windows 8 x64 Business Edition (Build 9200)) AppleWebKit\/536.27.1",
-            "mobile": false,
-            "tablet": false
-        },
-        {
-            "vendor": "Apple",
-            "user_agent": "Mozilla\/5.0 (iPod touch; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit\/537.51.1 (KHTML, like Gecko) Version\/7.0 Mobile\/11A4449d Safari\/9537.53",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Apple",
-            "user_agent": "Mozilla\/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit\/420+ (KHTML, like Gecko) Version\/3.0 Mobile\/1A543 Safari\/419.3",
-            "mobile": true,
-            "tablet": false,
-            "version": {
-                "Webkit": "420+",
-                "Safari": "3.0"
-            }
-        },
-        {
-            "vendor": "Apple",
-            "user_agent": "Mozilla\/5.0 (iPhone; U; CPU iPhone OS 3_0 like Mac OS X; en-us) AppleWebKit\/528.18 (KHTML, like Gecko) Version\/4.0 Mobile\/7A341 Safari\/528.16",
-            "mobile": true,
-            "tablet": false,
-            "version": {
-                "iOS": "3_0",
-                "Webkit": "528.18",
-                "Safari": "4.0"
-            },
-            "model": "iPhone"
-        },
-        {
-            "vendor": "Apple",
-            "user_agent": "Mozilla\/5.0 (iPhone; CPU iPhone OS 5_1_1 like Mac OS X) AppleWebKit\/534.46 (KHTML, like Gecko) Version\/5.1 Mobile\/9B206 Safari\/7534.48.3",
-            "mobile": true,
-            "tablet": false,
-            "version": {
-                "iOS": "5_1_1",
-                "Webkit": "534.46",
-                "Mobile": "9B206",
-                "Safari": "5.1"
-            },
-            "model": "iPhone"
-        },
-        {
-            "vendor": "Apple",
-            "user_agent": "Mozilla\/5.0 (iPod; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit\/536.26 (KHTML, like Gecko) Version\/6.0 Mobile\/10A403 Safari\/8536.25",
-            "mobile": true,
-            "tablet": false,
-            "version": {
-                "iOS": "6_0",
-                "Webkit": "536.26",
-                "Mobile": "10A403",
-                "Safari": "6.0"
-            },
-            "model": "iPod"
-        },
-        {
-            "vendor": "Apple",
-            "user_agent": "Mozilla\/5.0 (iPad; CPU OS 5_1_1 like Mac OS X; en-us) AppleWebKit\/534.46.0 (KHTML, like Gecko) CriOS\/21.0.1180.80 Mobile\/9B206 Safari\/7534.48.3 (6FF046A0-1BC4-4E7D-8A9D-6BF17622A123)",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "iOS": "5_1_1",
-                "Webkit": "534.46.0",
-                "Chrome": "21.0.1180.80",
-                "Mobile": "9B206"
-            },
-            "model": "iPad"
-        },
-        {
-            "vendor": "Apple",
-            "user_agent": "Mozilla\/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit\/536.26 (KHTML, like Gecko) Version\/6.0 Mobile\/10A403 Safari\/8536.25",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "iOS": "6_0",
-                "Webkit": "536.26",
-                "Safari": "6.0",
-                "Mobile": "10A403"
-            },
-            "model": "iPad"
-        },
-        {
-            "vendor": "Apple",
-            "user_agent": "Mozilla\/5.0 (iPad; U; CPU OS 4_2_1 like Mac OS X; en-us) AppleWebKit\/533.17.9 (KHTML, like Gecko) Version\/5.0.2 Mobile\/8C148 Safari\/6533.18.5",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "iOS": "4_2_1",
-                "Webkit": "533.17.9",
-                "Safari": "5.0.2",
-                "Mobile": "8C148"
-            },
-            "model": "iPad"
-        },
-        {
-            "vendor": "Apple",
-            "user_agent": "Mozilla\/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit\/531.21.10 (KHTML, like Gecko) Version\/4.0.4 Mobile\/7B334b Safari\/531.21.10",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "iOS": "3_2",
-                "Webkit": "531.21.10",
-                "Safari": "4.0.4",
-                "Mobile": "7B334b"
-            },
-            "model": "iPad"
-        },
-        {
-            "vendor": "Apple",
-            "user_agent": "Mozilla\/5.0 (iPhone; CPU iPhone OS 6_0_1 like Mac OS X; da-dk) AppleWebKit\/534.46.0 (KHTML, like Gecko) CriOS\/21.0.1180.82 Mobile\/10A523 Safari\/7534.48.3",
-            "mobile": true,
-            "tablet": false,
-            "version": {
-                "iOS": "6_0_1",
-                "Webkit": "534.46.0",
-                "Chrome": "21.0.1180.82",
-                "Mobile": "10A523"
-            },
-            "model": "iPhone"
-        },
-        {
-            "vendor": "Apple",
-            "user_agent": "Mozilla\/5.0 (iPhone; CPU iPhone OS 6_0_1 like Mac OS X) AppleWebKit\/536.26 (KHTML, like Gecko) Version\/6.0 Mobile\/10A523 Safari\/8536.25",
-            "mobile": true,
-            "tablet": false,
-            "version": {
-                "iOS": "6_0_1",
-                "Webkit": "536.26",
-                "Safari": "6.0",
-                "Mobile": "10A523"
-            },
-            "model": "iPhone"
-        },
-        {
-            "vendor": "Apple",
-            "user_agent": "Mozilla\/5.0 (iPhone; CPU iPhone OS 6_1 like Mac OS X; ru-ru) AppleWebKit\/536.26 (KHTML, like Gecko) CriOS\/23.0.1271.100 Mobile\/10B142 Safari\/8536.25",
-            "mobile": true,
-            "tablet": false,
-            "version": {
-                "iOS": "6_1",
-                "Webkit": "536.26",
-                "Chrome": "23.0.1271.100",
-                "Mobile": "10B142"
-            },
-            "model": "iPhone"
-        },
-        {
-            "vendor": "Apple",
-            "user_agent": "Mozilla\/5.0 (iPhone; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit\/536.26 (KHTML, like Gecko) Version\/6.0 Mobile\/10B329 Safari\/8536.25",
-            "mobile": true,
-            "tablet": false,
-            "version": {
-                "iOS": "6_1_3",
-                "Webkit": "536.26",
-                "Safari": "6.0",
-                "Mobile": "10B329"
-            },
-            "model": "iPhone"
-        },
-        {
-            "vendor": "Apple",
-            "user_agent": "Mozilla\/5.0 (iPad; CPU OS 6_1_3 like Mac OS X) AppleWebKit\/536.26 (KHTML, like Gecko) Coast\/1.0.2.62956 Mobile\/10B329 Safari\/7534.48.3",
-            "mobile": true,
-            "tablet": true,
-            "version": {
-                "Coast": "1.0.2.62956"
-            }
-        },
-        {
-            "vendor": "Apple",
-            "user_agent": "CheckMyBus iOS mobile App 0.9.0 (iPhone; iPhone OS\/7.1.1)",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Apple",
-            "user_agent": "Mozilla\/5.0 (iPad; CPU OS 7_0 like Mac OS X) AppleWebKit\/537.51.1 (KHTML, like Gecko) Version\/7.0 Mobile\/11A465 Safari\/9537.53",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Apple",
-            "user_agent": "Mozilla\/5.0 (iPhone; CPU iPhone OS 8_0_2 like Mac OS X) AppleWebKit\/600.1.4 (KHTML, like Gecko) CriOS\/38.0.2125.59 Mobile\/12A405 Safari\/600.1.4",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Apple",
-            "user_agent": "VendorAppName\/1.7.0 (iPhone; iOS 8.1.2; Scale\/3.00)",
-            "mobile": true,
-            "tablet": false,
-            "version": {
-                "iOS": "8.1.2"
-            },
-            "model": "iPhone"
-        },
-        {
-            "vendor": "Apple",
-            "user_agent": "Mozilla\/5.0 (iPad; CPU OS 9_0 like Mac OS X) AppleWebKit\/601.1.17 (KHTML, like Gecko) Version\/8.0 Mobile\/13A175 Safari\/600.1.4",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Apple",
-            "user_agent": "Mozilla\/5.0 (iPhone; CPU iPhone OS 9_0 like Mac OS X) AppleWebKit\/601.1.37 (KHTML, like Gecko) Version\/8.0 Mobile\/13A4293g Safari\/600.1.4",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Apple",
-            "user_agent": "Mozilla\/5.0 (iPad; CPU OS 9_0_2 like Mac OS X) AppleWebKit\/601.1.46 (KHTML, like Gecko) Version\/9.0 Mobile\/13A452 Safari\/601.1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "AOC",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; MW0922 Build\/IMM76D) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/42.0.2311.111 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "AOC",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; es-us; MW0831Plus Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Archos",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0; Archos 97c Platinum Build\/MRA58K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/52.0.2743.98 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Archos",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Qilive 97R Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/30.0.1599.92 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Archos",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; Archos 50 Platinum Build\/JZO54K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Archos",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; ARCHOS 80G9 Build\/IMM76D) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Archos",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2.1; fr-fr; A101IT Build\/FROYO) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Archos",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Archos 101 Neon Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Archos",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Archos 101 Cobalt Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Archos",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; de-de; ARCHOS 80 TITANIUM Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Archos",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; ARCHOS 101 Titanium Build\/JRO03H) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Archos",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; de-de; ARCHOS 70b TITANIUM Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Archos",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; de-de; Archos 80 Xenon Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Archos",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Archos 79 Xenon Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Archos",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; de-de; ARCHOS 101 Titanium Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Archos",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; de-de; ARCHOS 80XSK Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Archos",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; de-de; ARCHOS FAMILYPAD 2 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Archos",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; ARCHOS 97B TITANIUM Build\/JRO03H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Archos",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; ARCHOS 101 XS 2 Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Archos",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; ARCHOS 80b PLATINUM Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Archos",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Archos 70 Xenon Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Archos",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; de-de; ARCHOS 97 CARBON Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Archos",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; de-de; ARCHOS 97 TITANIUMHD Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Archos",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Archos 90 Neon Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Archos",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 1.6; de-de; Archos5 Build\/Donut) AppleWebKit\/528.5+ (KHTML, like Gecko) Version\/3.1.2 Mobile Safari\/525.20.1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Archos",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; de-de; ARCHOS GAMEPAD Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
             "vendor": "Verizon",
             "user_agent": "Mozilla\/5.0 (Linux; Android 5.1.1; QTAQZ3 Build\/LMY47V) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/56.0.2924.87 Safari\/537.36",
             "mobile": true,
@@ -8497,288 +5461,6 @@
         {
             "vendor": "Verizon",
             "user_agent": "Mozilla\/5.0(LInux;Android 5.1.1; QTAQTZ3 Build\/LMY47V) AppleWebKit\/537.36(KHTML, like Gecko) Chrome\/59.0.3071.125 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Onda",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; V975i Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/42.0.2311.108 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Onda",
-            "user_agent": "Mozilla\/5.0 (Android; Tablet; rv:37.0) Gecko\/37.0 Firefox\/37.0",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Onda",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; V975m Core4 Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Onda",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; fr-fr; V975m Core4 Build\/JSS15J) AppleWebKit\/537.16 (KHTML, like Gecko) Version\/4.0 Safari\/537.16",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Onda",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; V975m Core4 Build\/JSS15J) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/41.0.2272.96 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Onda",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; V812 Core4 Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/39.0.2171.93 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Mi",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2; xx-xx; HM NOTE 1W Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 MobilSafari\/534.30 XiaoMi\/MiuiBrowser\/1.0",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Mi",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.1; zh-cn; MI-ONE Plus Build\/ITL41D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30 XiaoMi\/MiuiBrowser\/1.0",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Mi",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; zh-cn; MI 2SC Build\/JRO03L) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30 XiaoMi\/MiuiBrowser\/1.0",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Mi",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; zh-cn; MI 2S Build\/JRO03L) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30 XiaoMi\/MiuiBrowser\/1.0",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Mi",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; zh-tw; MI 1S Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30 XiaoMi\/MiuiBrowser\/1.0",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Mi",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.8; zh-cn; xiaomi2 Build\/GRK39F) AppleWebKit\/533.1 (KHTML, like Gecko)Version\/4.0 MQQBrowser\/4.4 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Mi",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; es-es; MI 2A Build\/miui.es JRO03L) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30 XiaoMi\/MiuiBrowser\/1.0",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Mi",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.1; zh-cn; MI 3 Build\/JOP40D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30 XiaoMi\/MiuiBrowser\/1.0",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Mi",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; en-us; MI 1S Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30 XiaoMi\/MiuiBrowser\/1.0",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Mi",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; zh-cn; MI 3W Build\/JLS36C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30 XiaoMi\/MiuiBrowser\/1.0",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Mi",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; zh-cn; HM 1SC Build\/JLS36C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30 XiaoMi\/MiuiBrowser\/1.0",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Mi",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; en-us; HM 1SW Build\/JLS36C) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/537.36 XiaoMi\/MiuiBrowser\/2.0.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Mi",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; HM NOTE 1W Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/537.36 XiaoMi\/MiuiBrowser\/2.0.1",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Mi",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; en-us; MI-ONE C1 Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30 XiaoMi\/MiuiBrowser\/1.0",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Mi",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.4.4; en-us; MI 4W Build\/KTU84P) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/537.36 XiaoMi\/MiuiBrowser\/2.0.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Mi",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4; MI PAD Build\/KTU84P) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/33.0.0.0 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Allview",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; ALLVIEW P5 Build\/IML74K) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Allview",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us ; ALLVIEW SPEEDI Build\/IMM76D) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1\/UCBrowser\/8.5.3.246\/145\/355",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Allview",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; AllviewCity Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Allview",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; ALLVIEWSPEED Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Mpman",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; MPDC703 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Mpman",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; fr-fr; MPDC706 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Mpman",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; MPQC1010 Build\/KVT49L) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/30.0.0.0 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lava",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.6; en-us; Iris 349 Build\/MocorDroid2.3.5) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Lava",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; iris402+ Build\/iris402+) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Lava",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; IRIS402 Build\/LAVAIRIS402) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Lava",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; iris405 Build\/LAVAIRIS405) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Lava",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; IRIS_501 Build\/LAVAIRIS501) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Lava",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; iris402e Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Lava",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; iris503e Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Lava",
-            "user_agent": "UCWEB\/2.0 (Linux; U; Opera Mini\/7.1.32052\/30.3697; en-US; IRIS402) U2\/1.0.0 UCBrowser\/9.1.1.420 Mobile",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Lava",
-            "user_agent": "UCWEB\/2.0 (MIDP-2.0; U; Adr 4.2.2; en-US; IRIS402) U2\/1.0.0 UCBrowser\/9.1.1.420 U2\/1.0.0 Mobile",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Lava",
-            "user_agent": "UCWEB\/2.0 (Linux; U; Opera Mini\/7.1.32052\/30.3697; en-US; IRIS355) U2\/1.0.0 UCBrowser\/9.1.1.420 Mobile",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Lava",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; iris356 Build\/irisIRIS356) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 UCBrowser\/9.5.0.360 U3\/0.8.0 Mobile Safari\/533.1",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Lava",
-            "user_agent": "UCWEB\/2.0 (Linux; U; Opera Mini\/7.1.32052\/30.3697; en-US; iris356) U2\/1.0.0 UCBrowser\/9.0.2.389 Mobile",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Lava",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; iris500 Build\/iris500) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/30.0.0.0 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Lava",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; iris700 Build\/iris700) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/30.0.0.0 Mobile Safari\/537.36",
-            "mobile": true,
-            "tablet": false
-        },
-        {
-            "vendor": "Lava",
-            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; QPAD E704 Build\/JDQ39) AppleWebKit\/537.36 (KHTML like Gecko) Chrome\/36.0.1985.131 Safari\/537.36",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lava",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2; xx-xx; IvoryS Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lava",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; en-US; E-TAB IVORY Build\/E702) AppleWebKit\/534.31 (KHTML, like Gecko) UCBrowser\/9.3.0.321 U3\/0.8.0 Mobile Safari\/534.31",
-            "mobile": true,
-            "tablet": true
-        },
-        {
-            "vendor": "Lava",
-            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; tr-tr; E-TAB Build\/GRJ22) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
             "mobile": true,
             "tablet": true
         },
@@ -9296,6 +5978,1545 @@
             "tablet": false
         },
         {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2486.0 Safari\/537.36 Edge\/13.10586",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident\/6.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0)",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "IE": "10.0",
+                "Windows NT": "6.2",
+                "Trident": "6.0"
+            }
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident\/6.0)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident\/6.0; Touch)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident\/6.0; Touch; ARMBJS)",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Win64; x64; Trident\/6.0; Touch; MASMJS)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.2; WOW64; rv:25.0) Gecko\/20130626 Firefox\/25.0",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.2; WOW64; rv:22.0) Gecko\/20100101 Firefox\/22.0",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Win64; x64; Trident\/6.0; MDDCJS)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident\/6.0; MDDCJS)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.2; WOW64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.52 Safari\/537.36 OPR\/15.0.1147.130",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.2; WOW64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.116 Safari\/537.36",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Win64; x64; Trident\/6.0; Touch; MDDCJS; WebView\/1.0)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident\/6.0; IEMobile\/10.0; ARM; Touch; Microsoft; Lumia 640 XL LTE)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident\/6.0; IEMobile\/10.0; ARM; Touch; NOKIA; Lumia 520)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident\/6.0; IEMobile\/10.0; ARM; Touch; NOKIA; Lumia 620)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident\/6.0; IEMobile\/10.0; ARM; Touch; NOKIA; Lumia 822)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Lumia 800)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; Microsoft; Lumia 430 Dual SIM) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; Microsoft; Lumia 435) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; Microsoft; Lumia 532) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; Microsoft; Lumia 535) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; Microsoft; Lumia 535) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537 BMID\/E679DAAB6F",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; Microsoft; Lumia 640 LTE) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 1520) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 520) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 520) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537 UCBrowser\/4.2.1.541 Mobile",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 520; Vodafone) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 530) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 620) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 625) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 630 Dual SIM) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 630) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 635) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 635; Vodafone) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 735) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 820; Vodafone) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 830) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 925) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 930) like iPhone OS 7_0_3 Mac OS X AppleWebKit\/537 (KHTML, like Gecko) Mobile Safari\/537",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.2; ARM; Trident\/7.0; Touch; rv:11.0; WPDesktop; Lumia 635) like Gecko",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 550) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2486.0 Mobile Safari\/537.36 Edge\/13.10586",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 640 Dual SIM) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2486.0 Mobile Safari\/537.36 Edge\/13.10586",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 950 XL) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2486.0 Mobile Safari\/537.36 Edge\/13.10586",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 950) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2486.0 Mobile Safari\/537.36 Edge\/13.10586",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Windows Phone 10.0; Android 4.2.1; NOKIA; Lumia 625) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2486.0 Mobile Safari\/537.36 Edge\/13.10586",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Windows Phone 10.0; Android 4.2.1; NOKIA; Lumia 635) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2486.0 Mobile Safari\/537.36 Edge\/13.10586",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Windows Phone 10.0; Android 4.2.1; NOKIA; Lumia 830) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2486.0 Mobile Safari\/537.36 Edge\/14.14295",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Windows Phone 10.0; Android 4.2.1; NOKIA; Lumia 930) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2486.0 Mobile Safari\/537.36 Edge\/14.14295",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Windows Phone 8.1; ARM; Trident\/7.0; Touch; rv:11.0; IEMobile\/11.0; NOKIA; Lumia 530 Dual SIM) like Gecko",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Windows NT 10.0; ARM; Lumia 950 XL) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2486.0 Safari\/537.36 Edge\/13.10586",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Windows NT 10.0; ARM; Lumia 950) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2486.0 Safari\/537.36 Edge\/13.10586",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Windows NT 10.0; ARM; Lumia 930) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2486.0 Safari\/537.36 Edge\/13.10586",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Windows NT 10.0; ARM; Lumia 730 Dual SIM) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2486.0 Safari\/537.36 Edge\/13.10586",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "MOT-W510\/08.11.05R MIB\/BER2.2 Profile\/MIDP-2.0 Configuration\/CLDC-1.1 EGE\/1.0 UP.Link\/6.3.0.0.0",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2.2; zh-cn; ME722 Build\/MLS2GC_2.6.0) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; en-us; DROIDX Build\/4.5.1_57_DX8-51) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.5; en-us; MB855 Build\/4.5.1A-1_SUN-254_13) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.5; es-us; MB526 Build\/4.5.2-51_DFL-50) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.6; en-ca; MB860 Build\/4.5.2A-51_OLL-17.8) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.7; en-us; MOT-XT535 Build\/V1.540) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.7; ko-kr; A853 Build\/SHOLS_U2_05.26.3; CyanogenMod-7.1.2) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.0; en-us; Xoom Build\/HRI39) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.1; en-us; Xoom Build\/HMJ25) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; DROID RAZR 4G Build\/6.7.2-180_DHD-16_M4-31) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; Xoom Build\/IMM76L) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; pt-br; XT687 Build\/V2.27D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "Android": "4.0.4",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            },
+            "model": "XT687"
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; es-es; MOT-XT910 Build\/6.7.2-180_SPU-19-TA-11.6) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; XT910 Build\/9.8.2O-124_SPUL-17) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; XT915 Build\/2_32A_2031) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; XT919 Build\/2_290_2017) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.64 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; XT925 Build\/9.8.2Q-50-XT925_VQLM-20) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.90 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; XT907 Build\/9.8.1Q-66) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.90 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; XT901 Build\/9.8.2Q-50_SLS-13) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; DROID BIONIC Build\/9.8.2O-72_VZW-22) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; XT1022 Build\/KXC20.82-14) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.4.4; en-in; XT1022 Build\/KXC21.5-40) AppleWebKit\/537.16 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/537.16",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; XT1025 Build\/KXC20.82-13) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; XT1052 Build\/KLA20.16-2.16.2) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-gb; XT1052 Build\/13.9.0Q2.X_83) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; XT1053 Build\/13.9.0Q2.X_61) AppleWebKit\/537.31 (KHTML, like Gecko) Chrome\/26.0.1410.58 Mobile Safari\/537.31",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; XT1053 Build\/13.9.0Q2.X_55) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; XT1056 Build\/13.9.0Q2.X-116-MX-17-6-2) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.64 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; XT1031 Build\/KXB20.9-1.10-1.18-1.1) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.4; XT1032 Build\/KXB21.14-L1.40) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.4.2; de-de; XT1032 Build\/KLB20.9-1.10-1.24-1.1) AppleWebKit\/537.16 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/537.16",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; XT1034 Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; en-us; XT1034 Build\/14.10.0Q3.X-84-16) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; XT1035 Build\/14.10.0Q3.X-23) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/29.0.1547.59 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.3; XT1039 Build\/KXB21.14-L1.31) AppleWebKit\/537.36 (KHTML like Gecko) Chrome\/35.0.1916.141 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; en-us; XT919 Build\/2_290_2002) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; XT919 Build\/2_290_2004) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.90 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; en-us; XT920 Build\/2_290_2014) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; XT920 Build\/2_310_2014) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; XT905 Build\/7.7.1Q_GCIRD-16) AppleWebKit\/537.22 (KHTML, like Gecko) Chrome\/25.0.1364.169 Mobile Safari\/537.22",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; XT908 Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/30.0.0.0 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; XT897 Build\/7.7.1Q-6_SPR-ASANTI_LE-18) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 5.0.2; XT1032 Build\/LXB22.46-28.1) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/43.0.2357.92 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 5.1.1; Moto E Build\/LMY47V) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/39.0.0.0 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.4; XT1021 Build\/KTU84Q) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/33.0.0.0 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 5.0.2; XT1068 Build\/LXB22.46-28) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/54.0.2840.85 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0; XT1092 Build\/MPE24.49-18) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/54.0.2840.85 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Onda",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; V975i Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/42.0.2311.108 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Onda",
+            "user_agent": "Mozilla\/5.0 (Android; Tablet; rv:37.0) Gecko\/37.0 Firefox\/37.0",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Onda",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; V975m Core4 Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Onda",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; fr-fr; V975m Core4 Build\/JSS15J) AppleWebKit\/537.16 (KHTML, like Gecko) Version\/4.0 Safari\/537.16",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Onda",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; V975m Core4 Build\/JSS15J) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/41.0.2272.96 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Onda",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; V812 Core4 Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/39.0.2171.93 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Apple",
+            "user_agent": "iTunes\/9.1.1",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Apple",
+            "user_agent": "iTunes\/11.0.2 (Windows; Microsoft Windows 8 x64 Business Edition (Build 9200)) AppleWebKit\/536.27.1",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Apple",
+            "user_agent": "Mozilla\/5.0 (iPod touch; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit\/537.51.1 (KHTML, like Gecko) Version\/7.0 Mobile\/11A4449d Safari\/9537.53",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Apple",
+            "user_agent": "Mozilla\/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit\/420+ (KHTML, like Gecko) Version\/3.0 Mobile\/1A543 Safari\/419.3",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "Webkit": "420+",
+                "Safari": "3.0"
+            }
+        },
+        {
+            "vendor": "Apple",
+            "user_agent": "Mozilla\/5.0 (iPhone; U; CPU iPhone OS 3_0 like Mac OS X; en-us) AppleWebKit\/528.18 (KHTML, like Gecko) Version\/4.0 Mobile\/7A341 Safari\/528.16",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "iOS": "3_0",
+                "Webkit": "528.18",
+                "Safari": "4.0"
+            },
+            "model": "iPhone"
+        },
+        {
+            "vendor": "Apple",
+            "user_agent": "Mozilla\/5.0 (iPhone; CPU iPhone OS 5_1_1 like Mac OS X) AppleWebKit\/534.46 (KHTML, like Gecko) Version\/5.1 Mobile\/9B206 Safari\/7534.48.3",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "iOS": "5_1_1",
+                "Webkit": "534.46",
+                "Mobile": "9B206",
+                "Safari": "5.1"
+            },
+            "model": "iPhone"
+        },
+        {
+            "vendor": "Apple",
+            "user_agent": "Mozilla\/5.0 (iPod; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit\/536.26 (KHTML, like Gecko) Version\/6.0 Mobile\/10A403 Safari\/8536.25",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "iOS": "6_0",
+                "Webkit": "536.26",
+                "Mobile": "10A403",
+                "Safari": "6.0"
+            },
+            "model": "iPod"
+        },
+        {
+            "vendor": "Apple",
+            "user_agent": "Mozilla\/5.0 (iPad; CPU OS 5_1_1 like Mac OS X; en-us) AppleWebKit\/534.46.0 (KHTML, like Gecko) CriOS\/21.0.1180.80 Mobile\/9B206 Safari\/7534.48.3 (6FF046A0-1BC4-4E7D-8A9D-6BF17622A123)",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "iOS": "5_1_1",
+                "Webkit": "534.46.0",
+                "Chrome": "21.0.1180.80",
+                "Mobile": "9B206"
+            },
+            "model": "iPad"
+        },
+        {
+            "vendor": "Apple",
+            "user_agent": "Mozilla\/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit\/536.26 (KHTML, like Gecko) Version\/6.0 Mobile\/10A403 Safari\/8536.25",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "iOS": "6_0",
+                "Webkit": "536.26",
+                "Safari": "6.0",
+                "Mobile": "10A403"
+            },
+            "model": "iPad"
+        },
+        {
+            "vendor": "Apple",
+            "user_agent": "Mozilla\/5.0 (iPad; U; CPU OS 4_2_1 like Mac OS X; en-us) AppleWebKit\/533.17.9 (KHTML, like Gecko) Version\/5.0.2 Mobile\/8C148 Safari\/6533.18.5",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "iOS": "4_2_1",
+                "Webkit": "533.17.9",
+                "Safari": "5.0.2",
+                "Mobile": "8C148"
+            },
+            "model": "iPad"
+        },
+        {
+            "vendor": "Apple",
+            "user_agent": "Mozilla\/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit\/531.21.10 (KHTML, like Gecko) Version\/4.0.4 Mobile\/7B334b Safari\/531.21.10",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "iOS": "3_2",
+                "Webkit": "531.21.10",
+                "Safari": "4.0.4",
+                "Mobile": "7B334b"
+            },
+            "model": "iPad"
+        },
+        {
+            "vendor": "Apple",
+            "user_agent": "Mozilla\/5.0 (iPhone; CPU iPhone OS 6_0_1 like Mac OS X; da-dk) AppleWebKit\/534.46.0 (KHTML, like Gecko) CriOS\/21.0.1180.82 Mobile\/10A523 Safari\/7534.48.3",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "iOS": "6_0_1",
+                "Webkit": "534.46.0",
+                "Chrome": "21.0.1180.82",
+                "Mobile": "10A523"
+            },
+            "model": "iPhone"
+        },
+        {
+            "vendor": "Apple",
+            "user_agent": "Mozilla\/5.0 (iPhone; CPU iPhone OS 6_0_1 like Mac OS X) AppleWebKit\/536.26 (KHTML, like Gecko) Version\/6.0 Mobile\/10A523 Safari\/8536.25",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "iOS": "6_0_1",
+                "Webkit": "536.26",
+                "Safari": "6.0",
+                "Mobile": "10A523"
+            },
+            "model": "iPhone"
+        },
+        {
+            "vendor": "Apple",
+            "user_agent": "Mozilla\/5.0 (iPhone; CPU iPhone OS 6_1 like Mac OS X; ru-ru) AppleWebKit\/536.26 (KHTML, like Gecko) CriOS\/23.0.1271.100 Mobile\/10B142 Safari\/8536.25",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "iOS": "6_1",
+                "Webkit": "536.26",
+                "Chrome": "23.0.1271.100",
+                "Mobile": "10B142"
+            },
+            "model": "iPhone"
+        },
+        {
+            "vendor": "Apple",
+            "user_agent": "Mozilla\/5.0 (iPhone; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit\/536.26 (KHTML, like Gecko) Version\/6.0 Mobile\/10B329 Safari\/8536.25",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "iOS": "6_1_3",
+                "Webkit": "536.26",
+                "Safari": "6.0",
+                "Mobile": "10B329"
+            },
+            "model": "iPhone"
+        },
+        {
+            "vendor": "Apple",
+            "user_agent": "Mozilla\/5.0 (iPad; CPU OS 6_1_3 like Mac OS X) AppleWebKit\/536.26 (KHTML, like Gecko) Coast\/1.0.2.62956 Mobile\/10B329 Safari\/7534.48.3",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Coast": "1.0.2.62956"
+            }
+        },
+        {
+            "vendor": "Apple",
+            "user_agent": "CheckMyBus iOS mobile App 0.9.0 (iPhone; iPhone OS\/7.1.1)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Apple",
+            "user_agent": "Mozilla\/5.0 (iPad; CPU OS 7_0 like Mac OS X) AppleWebKit\/537.51.1 (KHTML, like Gecko) Version\/7.0 Mobile\/11A465 Safari\/9537.53",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Apple",
+            "user_agent": "Mozilla\/5.0 (iPhone; CPU iPhone OS 8_0_2 like Mac OS X) AppleWebKit\/600.1.4 (KHTML, like Gecko) CriOS\/38.0.2125.59 Mobile\/12A405 Safari\/600.1.4",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Apple",
+            "user_agent": "VendorAppName\/1.7.0 (iPhone; iOS 8.1.2; Scale\/3.00)",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "iOS": "8.1.2"
+            },
+            "model": "iPhone"
+        },
+        {
+            "vendor": "Apple",
+            "user_agent": "Mozilla\/5.0 (iPad; CPU OS 9_0 like Mac OS X) AppleWebKit\/601.1.17 (KHTML, like Gecko) Version\/8.0 Mobile\/13A175 Safari\/600.1.4",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Apple",
+            "user_agent": "Mozilla\/5.0 (iPhone; CPU iPhone OS 9_0 like Mac OS X) AppleWebKit\/601.1.37 (KHTML, like Gecko) Version\/8.0 Mobile\/13A4293g Safari\/600.1.4",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Apple",
+            "user_agent": "Mozilla\/5.0 (iPad; CPU OS 9_0_2 like Mac OS X) AppleWebKit\/601.1.46 (KHTML, like Gecko) Version\/9.0 Mobile\/13A452 Safari\/601.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9300; en) AppleWebKit\/534.8+ (KHTML, like Gecko) Version\/6.0.0.546 Mobile Safari\/534.8+",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "Webkit": "534.8+",
+                "BlackBerry": "6.0.0.546"
+            },
+            "model": "BlackBerry 9300"
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9360; en-US) AppleWebKit\/534.11+ (KHTML, like Gecko) Version\/7.0.0.400 Mobile Safari\/534.11+",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9700; he) AppleWebKit\/534.8+ (KHTML, like Gecko) Version\/6.0.0.723 Mobile Safari\/534.8+",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9700; en-US) AppleWebKit\/534.8  (KHTML, like Gecko) Version\/6.0.0.448 Mobile Safari\/534.8",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9790; en-GB) AppleWebKit\/534.11+ (KHTML, like Gecko) Version\/7.1.0.714 Mobile Safari\/534.11+",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "Webkit": "534.11+",
+                "BlackBerry": "7.1.0.714"
+            },
+            "model": "BlackBerry 9790"
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Opera\/9.80 (BlackBerry; Opera Mini\/7.0.29990\/28.2504; U; en) Presto\/2.8.119 Version\/11.10",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9981; en-GB) AppleWebKit\/534.11+ (KHTML, like Gecko) Version\/7.1.0.342 Mobile Safari\/534.11+",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9800; en-GB) AppleWebKit\/534.8+ (KHTML, like Gecko) Version\/6.0.0.546 Mobile Safari\/534.8+",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9780; es) AppleWebKit\/534.8  (KHTML, like Gecko) Version\/6.0.0.480 Mobile Safari\/534.8",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9810; en-US) AppleWebKit\/534.11  (KHTML, like Gecko) Version\/7.0.0.583 Mobile Safari\/534.11",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9860; es) AppleWebKit\/534.11+ (KHTML, like Gecko) Version\/7.0.0.576 Mobile Safari\/534.11+",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9900; en-US) AppleWebKit\/534.11  (KHTML, like Gecko) Version\/7.1.0.523 Mobile Safari\/534.11",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "BlackBerry8520\/5.0.0.592 Profile\/MIDP-2.1 Configuration\/CLDC-1.1 VendorID\/136",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "BlackBerry8520\/5.0.0.1067 Profile\/MIDP-2.1 Configuration\/CLDC-1.1 VendorID\/603",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "BlackBerry8520\/5.0.0.1036 Profile\/MIDP-2.1 Configuration\/CLDC-1.1 VendorID\/611",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "BlackBerry": "5.0.0.1036",
+                "VendorID": "611"
+            },
+            "model": "BlackBerry8520"
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9220; en) AppleWebKit\/534.11+ (KHTML, like Gecko) Version\/7.1.0.337 Mobile Safari\/534.11+",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit\/536.2+ (KHTML, like Gecko) Version\/7.2.1.0 Safari\/536.2+",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BB10; Touch) AppleWebKit\/537.1+ (KHTML, like Gecko) Version\/10.0.0.1337 Mobile Safari\/537.1+",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BB10; Touch) AppleWebKit\/537.10+ (KHTML, like Gecko) Version\/10.0.9.2372 Mobile Safari\/537.10+",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BB10; Touch) \/537.10+ (KHTML, like Gecko) Version\/10.0.9.2372 Mobile Safari\/537.10+",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "BlackBerry": "10.0.9.2372"
+            }
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2.1; en-us; Transformer TF101 Build\/HTK75) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "3.2.1",
+                "Webkit": "534.13",
+                "Safari": "4.0"
+            },
+            "model": "Transformer TF101"
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; de-de; A200 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.3",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            },
+            "model": "A200"
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; A500 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.3",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            },
+            "model": "A500"
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; A501 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.3",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            },
+            "model": "A501"
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; Transformer Build\/JRO03L) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.1",
+                "Webkit": "535.19",
+                "Chrome": "18.0.1025.166"
+            },
+            "model": "Transformer"
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; ASUS Transformer Pad TF300T Build\/JRO03C) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.1",
+                "Webkit": "535.19",
+                "Chrome": "18.0.1025.166"
+            },
+            "model": "Transformer Pad TF300T"
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; fr-fr; Transformer Build\/JZO54K; CyanogenMod-10) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.2",
+                "Webkit": "534.30",
+                "Safari": "4.0",
+                "Build": "JZO54K"
+            },
+            "model": "Transformer"
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; B1-A71 Build\/JZO54K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.2",
+                "Webkit": "535.19",
+                "Chrome": "18.0.1025.166"
+            },
+            "model": "B1-A71"
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Acer; Allegro)",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "Windows Phone OS": "7.5",
+                "Trident": "5.0",
+                "IE": "9.0"
+            },
+            "model": "Allegro"
+        },
+        {
+            "vendor": "Allview",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; ALLVIEW P5 Build\/IML74K) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Allview",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us ; ALLVIEW SPEEDI Build\/IMM76D) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1\/UCBrowser\/8.5.3.246\/145\/355",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Allview",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; AllviewCity Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Allview",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; ALLVIEWSPEED Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Mpman",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; MPDC703 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Mpman",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; fr-fr; MPDC706 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Mpman",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; MPQC1010 Build\/KVT49L) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/30.0.0.0 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "HP",
+            "user_agent": "Mozilla\/5.0 (hp-tablet; Linux; hpwOS\/3.0.5; U; en-GB) AppleWebKit\/534.6 (KHTML, like Gecko) wOSBrowser\/234.83 Safari\/534.6 TouchPad\/1.0",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "HP",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; HP Slate 7 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "HP",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; HP Slate 7 Build\/JRO03H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "HP",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; HP 8 Build\/1.0.7_WW-FIR-13) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "HP",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; HP Slate 10 HD Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "HP",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; HP Slate 8 Pro Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "HP",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Slate 21 Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.138 Safari\/537.36 OPR\/22.0.1485.78487",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "HP",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; HP SlateBook 10 x2 PC Build\/4.3-17r20-03-23) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2.1; en-us; Transformer TF101 Build\/HTK75) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "3.2.1",
+                "Webkit": "534.13",
+                "Safari": "4.0"
+            },
+            "model": "Transformer TF101"
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; Transformer Build\/JRO03L) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; ASUS Transformer Pad TF300T Build\/JRO03C) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; fr-fr; Transformer Build\/JZO54K; CyanogenMod-10) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; asus_laptop Build\/IMM76L) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; PadFone 2 Build\/JRO03L) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; PadFone 2 Build\/JRO03L) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.1",
+                "Build": "JRO03L",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.1; ME301T Build\/JOP40D) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Safari\/537.36",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.2.1",
+                "Build": "JOP40D"
+            }
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.1; ME173X Build\/JOP40D) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Safari\/537.36",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.2.1",
+                "Build": "JOP40D"
+            }
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; TF300T Build\/JDQ39E) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.2.2",
+                "Build": "JDQ39E"
+            }
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; K00C Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; K00E Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; K00F Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; K00L Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/36.0.1985.131 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; ME302KL Build\/JDQ39) AppleWebKit\/537.31 (KHTML, like Gecko) Chrome\/26.0.1410.58 Safari\/537.31",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; K010 Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/42.0.2311.111 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; K017 Build\/KVT49L) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/42.0.2311.111 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 5.0; PO1MA build\/LRX21V) AppelWebKit\/537.36 (KHTML, like Gecko) Chrome\/39.0.2171.93 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0(Linus; Android 4.4.2; K011 Build\/KOT49H)AppleWebKit\/537.36 (KHTML, like Gecko)Chrome\/53.0.2785.124 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 5.0.2; K01E Build\/LRX22G) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/39.0.2171.93 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 5.0.2; P01Z Build\/LRX22G; wv) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0; P027 Build\/MRA58L) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/56.0.2924.87 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0.1; P024 Build\/MMB29M) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/61.0.3163.100 YaBrowser\/17.10.2.145.01 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0.1; P024 Build\/MMB29M) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/58.0.3029.83 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 7.0; P00C Build\/NRD90M) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/56.0.2924.87 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0; Archos 97c Platinum Build\/MRA58K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/52.0.2743.98 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Qilive 97R Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/30.0.1599.92 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; Archos 50 Platinum Build\/JZO54K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; ARCHOS 80G9 Build\/IMM76D) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2.1; fr-fr; A101IT Build\/FROYO) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Archos 101 Neon Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Archos 101 Cobalt Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; de-de; ARCHOS 80 TITANIUM Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; ARCHOS 101 Titanium Build\/JRO03H) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; de-de; ARCHOS 70b TITANIUM Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; de-de; Archos 80 Xenon Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Archos 79 Xenon Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; de-de; ARCHOS 101 Titanium Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; de-de; ARCHOS 80XSK Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; de-de; ARCHOS FAMILYPAD 2 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; ARCHOS 97B TITANIUM Build\/JRO03H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; ARCHOS 101 XS 2 Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; ARCHOS 80b PLATINUM Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Archos 70 Xenon Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; de-de; ARCHOS 97 CARBON Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; de-de; ARCHOS 97 TITANIUMHD Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Archos 90 Neon Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 1.6; de-de; Archos5 Build\/Donut) AppleWebKit\/528.5+ (KHTML, like Gecko) Version\/3.1.2 Mobile Safari\/525.20.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; de-de; ARCHOS GAMEPAD Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
             "vendor": "Prestigio",
             "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-gb; PMP5297C_QUAD Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
             "mobile": true,
@@ -9341,6 +7562,1791 @@
         {
             "vendor": "Prestigio",
             "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; el-gr; PMT5887_3G Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Avant",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.1; WOW64; Trident\/7.0; Avant Browser; rv:11.0) like Gecko",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Avant",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.1; WOW64; Avant TriCore) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/30.0.1599.101 Safari\/537.36",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Avant",
+            "user_agent": "Mozilla\/5.0 (Windows NT 5.1; rv:27.0; Avant TriCore) Gecko\/20100101 Firefox\/27.0",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Console",
+            "user_agent": "Mozilla\/5.0 (Nintendo WiiU) AppleWebKit\/536.28 (KHTML, like Gecko) NX\/3.0.3.12.14 NintendoBrowser\/3.1.1.9577.EU",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Console",
+            "user_agent": "Mozilla\/5.0 (Nintendo WiiU) AppleWebKit\/534.52 (KHTML, like Gecko) NX\/{Version No} NintendoBrowser\/{Version No}.US",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Console",
+            "user_agent": "Mozilla\/5.0 (Nintendo 3DS; U; ; en) Version\/1.7567.US",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Console",
+            "user_agent": "Mozilla\/5.0 (Nintendo 3DS; U; ; en) Version\/1.7498.US",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Console",
+            "user_agent": "Mozilla\/5.0 (PLAYSTATION 3 4.21) AppleWebKit\/531.22.8 (KHTML, like Gecko)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Console",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident\/5.0; Xbox)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/53.0.2785.148 Safari\/537.36 Vivaldi\/1.4.589.41",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident\/4.0; SV1; [eburo v4.0]; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; InfoPath.3; .NET4.0C; .NET4.0E)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_10) AppleWebKit\/600.1.25 (KHTML, like Gecko) Version\/8.0 Safari\/600.1.25",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/38.0.2125.111 Safari\/537.36",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.1) AppleWebKit\/537.36 (KHTML, like Gecko) Iron\/37.0.2000.0 Chrome\/37.0.2000.0 Safari\/537.36",
+            "mobile": false,
+            "tablet": false,
+            "version": {
+                "Iron": "37.0.2000.0"
+            }
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (X11; Linux i686) AppleWebKit\/537.36 (KHTML, like Gecko) Ubuntu Chromium\/32.0.1700.102 Chrome\/32.0.1700.102 Safari\/537.36",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.1; WOW64; rv:24.0) Gecko\/20100101 Firefox\/24.0",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.1; WOW64; rv:18.0) Gecko\/20100101 Firefox\/18.0 AlexaToolbar\/psPCtGhf-2.2",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (X11; Ubuntu; Linux x86_64; rv:22.0) Gecko\/20100101 Firefox\/22.0",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (X11; Linux ppc; rv:17.0) Gecko\/20130626 Firefox\/17.0 Iceweasel\/17.0.7",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (X11; Linux) AppleWebKit\/535.22+ Midori\/0.4",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (Macintosh; U; Intel Mac OS X; en-us) AppleWebKit\/535+ (KHTML, like Gecko) Version\/5.0 Safari\/535.20+ Midori\/0.4",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.2; WOW64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.20 Safari\/537.36  OPR\/15.0.1147.18 (Edition Next)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.2) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.94 Safari\/537.36",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (Windows NT 5.2; WOW64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.94 Safari\/537.36",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (Windows NT 5.2; WOW64; rv:21.0) Gecko\/20100101 Firefox\/21.0",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Opera\/9.80 (Windows NT 5.2; WOW64) Presto\/2.12.388 Version\/12.14",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.1; WOW64; rv:19.0) Gecko\/20100101 Firefox\/19.0",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (X11; FreeBSD amd64; rv:14.0) Gecko\/20100101 Firefox\/14.0.1",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/4.0 (compatible; MSIE 7.0; Windows NT 6.2; Win64; x64; Trident\/6.0; Touch; .NET4.0E; .NET4.0C; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET CLR 2.0.50727; Tablet PC 2.0; MASMJS)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident\/6.0; MANMJS)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Win64; x64; Trident\/6.0; MASMJS)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident\/6.0; Touch; MASMJS)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Opera\/9.80 (Windows NT 6.2; WOW64; MRA 8.0 (build 5784)) Presto\/2.12.388 Version\/12.11",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident\/6.0)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.3; Trident\/7.0; rv 11.0) like Gecko",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.3; WOW64; Trident\/7.0; Touch; rv:11.0) like Gecko",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (Unknown; Linux armv7l) AppleWebKit\/537.1+ (KHTML, like Gecko) Safari\/537.1+ HbbTV\/1.1.1 ( ;LGE ;NetCast 4.0 ;03.20.30 ;1.0M ;)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "HbbTV\/1.1.1 (;Panasonic;VIERA 2012;1.261;0071-3103 2000-0000;)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Opera\/9.80 (Linux armv7l; HbbTV\/1.1.1 (; Sony; KDL32W650A; PKG3.211EUA; 2013;); ) Presto\/2.12.362 Version\/12.11",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "TV",
+            "user_agent": "Mozilla\/5.0 (SMART-TV; Linux; Tizen 2.3) AppleWebkit\/538.1 (KHTML, like Gecko) SamsungBrowser\/1.0 TV Safari\/538.1",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Windows NT 10.0; Win64; x64; rv:38.9) Gecko\/20100101 Goanna\/2.0 Firefox\/38.9 PaleMoon\/26.0.0",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Windows NT 10.0; Win64; x64; rv:2.0) Gecko\/20100101 Goanna\/20160121 PaleMoon\/26.0.0",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Windows NT 10.0; Win64; x64; rv:38.9) Gecko\/20100101 Goanna\/2.0 Firefox\/38.9 PaleMoon\/26.1.1",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Maemo; Linux; U; Jolla; Sailfish; Mobile; rv:31.0) Gecko\/31.0 Firefox\/31.0 SailfishBrowser\/1.0",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Maemo; Linux; U; Jolla; Sailfish; Tablet; rv:31.0) Gecko\/31.0 Firefox\/31.0 SailfishBrowser\/1.0",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Mobile; rv:26.0) Gecko\/26.0 Firefox\/26.0",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Tablet; rv:26.0) Gecko\/26.0 Firefox\/26.0",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; CT1020W Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; M6pro Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "MobileSafari\/9537.53 CFNetwork\/672.1.13 Darwin\/13.1.0",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Appcelerator Titanium\/3.2.2.GA (iPod touch\/6.1.6; iPhone OS; en_US;)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera Coast\/3.0.3.78307 CFNetwork\/672.1.15 Darwin\/14.0.0",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; ALUMIUM10 Build\/IML74K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.1; en-us; JY-G3 Build\/JOP40D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; hu-hu; M758A Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; EVOTAB Build\/IMM76I) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Java\/1.6.0_22",
+            "mobile": false,
+            "tablet": false,
+            "version": {
+                "Java": "1.6.0_22"
+            }
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (Series 60; Opera Mini\/6.5.29260\/29.3417; U; ru) Presto\/2.8.119 Version\/11.10",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (Android; Opera Mini\/6.5.27452\/29.3417; U; ru) Presto\/2.8.119 Version\/11.10",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (iPhone; Opera Mini\/7.1.32694\/27.1407; U; en) Presto\/2.8.119 Version\/11.10",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.1; WOW64) AppleWebKit\/537.17 (KHTML, like Gecko) Chrome\/24.0.1312.60 Safari\/537.17 OPR\/14.0.1025.52315",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (iPhone; U; CPU iPhone OS 4_3_2 like Mac OS X; en-us) AppleWebKit\/533.17.9 (KHTML, like Gecko) Version\/5.0.2 Mobile\/8H7 Safari\/6533.18.5",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (Android 2.3.7; Linux; Opera Mobi\/46154) Presto\/2.11.355 Version\/12.10",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (iPad; CPU OS 6_1 like Mac OS X) AppleWebKit\/536.26 (KHTML, like Gecko) Version\/6.0 Mobile\/10B141 Safari\/8536.25",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; en-us; sdk Build\/MASTER) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2; en-us; sdk Build\/JB_MR1) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Android; Mobile; rv:18.0) Gecko\/18.0 Firefox\/18.0",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.1) AppleWebKit\/535.12 (KHTML, like Gecko) Maxthon\/3.0 Chrome\/18.0.966.0 Safari\/535.12",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (Windows NT 5.1; U; Edition Yx; ru) Presto\/2.10.289 Version\/12.02",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/4.0 (compatible; MSIE 6.0; Windows NT 5.1; Windows Phone 6.5.3.5)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "PalmCentro\/v0001 Mozilla\/4.0 (compatible; MSIE 6.0; Windows 98; PalmSource\/Palm-D061; Blazer\/4.5) 16;320x320",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Microsoft; XDeviceEmulator)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; MAL; N880E; China Telecom)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (Series 60; Opera Mini\/7.0.29482\/28.2859; U; ru) Presto\/2.8.119 Version\/11.10",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (S60; SymbOS; Opera Mobi\/SYB-1202242143; U; en-GB) Presto\/2.10.254 Version\/12.00",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-au; 97D Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (Android; Opera Mini\/7.0.29952\/28.2647; U; ru) Presto\/2.8.119 Version\/11.10",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (Android; Opera Mini\/6.1.25375\/28.2555; U; en) Presto\/2.8.119 Version\/11.10",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (Mac OS X; Opera Tablet\/35779; U; en) Presto\/2.10.254 Version\/12.00",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Android; Tablet; rv:10.0.4) Gecko\/10.0.4 Firefox\/10.0.4 Fennec\/10.0.4",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Android; Tablet; rv:18.0) Gecko\/18.0 Firefox\/18.0",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (Linux armv7l; Maemo; Opera Mobi\/14; U; en) Presto\/2.9.201 Version\/11.50",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (Android 2.2.1; Linux; Opera Mobi\/ADR-1207201819; U; en) Presto\/2.10.254 Version\/12.00",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; sdk Build\/JRO03E) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; Endeavour 1010 Build\/ONDA_MID) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; de-de; Tablet-PC-4 Build\/ICS.g08refem618.20121102) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; Tagi Tab S10 Build\/8089) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Bot",
+            "user_agent": "Mozilla\/5.0 (compatible; Googlebot\/2.1; +http:\/\/www.google.com\/bot.html)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Bot",
+            "user_agent": "grub-client-1.5.3; (grub-client-1.5.3; Crawl your own stuff with http:\/\/grub.org)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Bot",
+            "user_agent": "Googlebot-Image\/1.0",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Bot",
+            "user_agent": "Python-urllib\/2.5",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Bot",
+            "user_agent": "facebookexternalhit\/1.0 (+http:\/\/www.facebook.com\/externalhit_uatext.php)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Bot",
+            "user_agent": "AdsBot-Google (+http:\/\/www.google.com\/adsbot.html)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Bot",
+            "user_agent": "AdsBot-Google-Mobile (+http:\/\/www.google.com\/mobile\/adsbot.html) Mozilla (iPhone; U; CPU iPhone OS 3 0 like Mac OS X) AppleWebKit (KHTML, like Gecko) Mobile Safari",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Bot",
+            "user_agent": "Mozilla\/5.0 (X11; U; Linux x86_64; en-US) AppleWebKit\/534.16 (KHTML, like Gecko, Google Keyword Suggestion) Chrome\/10.0.648.127 Safari\/534.16",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Bot",
+            "user_agent": "Facebot",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Vodafone",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2; hu-hu; SmartTab10-MSM8260-V02d-Dec022011-Vodafone-HU) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Vodafone",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; SmartTabII10 Build\/IML74K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Vodafone",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; fr-fr; SmartTAB 1002 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Vodafone",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; de-de, SmartTabII7 Build\/A2107A_A404_107_055_130124_VODA) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Google",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2; en-us; Nexus One Build\/FRF91) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Google",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Nexus 4 Build\/JDQ39) AppleWebKit\/537.31 (KHTML, like Gecko) Chrome\/26.0.1410.40 Mobile Safari\/537.31 OPR\/14.0.1074.54070",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "Android": "4.2.2",
+                "Build": "JDQ39",
+                "Webkit": "537.31",
+                "Opera": "14.0.1074.54070"
+            }
+        },
+        {
+            "vendor": "Google",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Nexus 4 Build\/JDQ39) AppleWebKit\/537.31 (KHTML, like Gecko) Chrome\/26.0.1410.58 Mobile Safari\/537.31",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "Android": "4.2.2",
+                "Chrome": "26.0.1410.58"
+            }
+        },
+        {
+            "vendor": "Google",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; Google Nexus 4 - 4.1.1 - API 16 - 768x1280 Build\/JRO03S) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Google",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; Google Galaxy Nexus - 4.1.1 - API 16 - 720x1280 Build\/JRO03S) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Google",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; Nexus 7 Build\/JRO03D) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Google",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2; Nexus 7 Build\/JOP40C) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Google",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; Nexus 7 Build\/JZ054K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.2",
+                "Chrome": "18.0.1025.166"
+            }
+        },
+        {
+            "vendor": "Google",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; cs-cz; Nexus S Build\/JZO54K; CyanogenMod-10.0.0) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Google",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; Nexus 10 Build\/JWR66Y) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/29.0.1547.72 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Google",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android; en_us; Nexus 7 Build\/) AppleWebKit\/530.17 (KHTML, like Gecko) Version\/4.0 NetFrontLifeBrowser\/2.3 Mobile (Dragonfruit)",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Google",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 5.1; Nexus 5 Build\/LMY47D) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/39.0.0.0 Mobile Safari\/537.36 momoWebView\/6.3.1 android\/404(Nexus 5;android 5.1;zh_CN;10;netType\/1)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Google",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; Nexus 10 Build\/JWR66Y) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/30.0.1599.92 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Google",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 7.1; Pixel XL Build\/NDE63H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/54.0.2840.85 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Google",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 7.1; Pixel Build\/NDE63H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/54.0.2840.85 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Google",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 8.1.0; Pixel C Build\/OPM1.171019.011; wv) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/65.0.3325.109 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Google",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 8.1.0; Pixel C Build\/OPM1.171019.026) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/66.0.3359.126 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Google",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 8.1.0; Pixel 2 Build\/OPM2.171026.006.G1) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/67.0.3396.87 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2.1; en-us; A100 Build\/HTK55D) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1; en-us; A110 Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; de-de; A200 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.3",
+                "Webkit": "534.30",
+                "Safari": "4.0",
+                "Build": "IML74K"
+            },
+            "model": "A200"
+        },
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; A500 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; A501 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; A701 Build\/JRO03H) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; B1-A71 Build\/JZO54K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; B1-710 Build\/JZO54K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/29.0.1547.72 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; A1-810 Build\/JDQ39) AppleWebKit\/537.31 (KHTML, like Gecko) Chrome\/26.0.1410.58 Safari\/537.31",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; nl-nl; A1-810 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Acer; Allegro)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; A3-A10 Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Safari\/537.36",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.2.2",
+                "Build": "JDQ39",
+                "Webkit": "537.36",
+                "Chrome": "32.0.1700.99"
+            }
+        },
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; A1-811 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; A1-830 Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; A3-A11 Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Amazon",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; KFTT Build\/IML74K) AppleWebKit\/535.19 (KHTML, like Gecko) Silk\/3.4 Mobile Safari\/535.19 Silk-Accelerated =true",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Amazon",
+            "user_agent": "Mozilla\/5.0 (Linux; U; en-US) AppleWebKit\/528.5+ (KHTML, like Gecko, Safari\/528.5+) Version\/4.0 Kindle\/3.0 (screen 600x800; rotate)",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Webkit": "528.5+",
+                "Kindle": "3.0",
+                "Safari": "4.0"
+            },
+            "model": "Kindle"
+        },
+        {
+            "vendor": "Amazon",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; KFOTE Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.3",
+                "Build": "IML74K",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Amazon",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; WFJWAE Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Amazon",
+            "user_agent": "Mozilla\/5.0 (Linux; U; en-us; KFTT Build\/IML74K) AppleWebKit\/535.19 (KHTML, like Gecko) Silk\/3.21 Safari\/535.19 Silk-Accelerated=true",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Amazon",
+            "user_agent": "Mozilla\/5.0 (Linux; U; en-us; KFTHWI Build\/JDQ39) AppleWebKit\/535.19 (KHTML, like Gecko) Silk\/3.21 Safari\/535.19 Silk-Accelerated=true",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Amazon",
+            "user_agent": "Mozilla\/5.0 (Linux; U; en-us; KFJWI Build\/IMM76D) AppleWebKit\/535.19 (KHTML, like Gecko) Silk\/3.21 Safari\/535.19 Silk-Accelerated=true",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Amazon",
+            "user_agent": "Mozilla\/5.0 (Linux; U; en-us; KFSOWI Build\/JDQ39) AppleWebKit\/535.19 (KHTML, like Gecko) Silk\/3.21 Safari\/535.19 Silk-Accelerated=true",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Amazon",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.1; xx-xx; T720-WIFI Build\/ECLAIR) AppleWebKit\/530.17 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/530.17",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Amazon",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 5.1; KFARWI Build\/LMY47O) AppleWebKit\/537.36 (KHTML, like Gecko) Silk\/47.1.79 like Chrome\/47.0.2526.80 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Amazon",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.3; KFTHWI Build\/KTU84M) AppleWebKit\/537.36 (KHTML, like Gecko) Silk\/44.1.54 like Chrome\/44.0.2403.63 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Amazon",
+            "user_agent": "Mozilla\/5.0 (X11; Linux x86_64) AppleWebKit\/537.36 (KHTML, like Gecko) Silk\/44.1.54 like Chrome\/44.0.2403.63 Safari\/537.36",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Amazon",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 5.1.1; KFASWI Build\/LMY47O) AppleWebKit\/537.36 (KHTML, like Gecko) Silk\/48.2.2 like Chrome\/48.0.2564.95 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Amazon",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 5.1.1; KFFOWI Build\/LMY47O) AppleWebKit\/537.36 (KHTML, like Gecko) Silk\/46.1.66 like Chrome\/46.0.2490.80 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Amazon",
+            "user_agent": "Mozilla\/5.0 (Linux; U; en-us; KFAPWI Build\/JDQ39) AppleWebKit\/535.19 (KHTML, like Gecko) Silk\/3.13 Safari\/535.19 Silk-Accelerated=true",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Amazon",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 5.1.1; KFGIWI Build\/LVY48F) AppleWebKit\/537.36 (KHTML, like Gecko) Silk\/56.2.4 like Chrome\/56.0.2924.87 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Amazon",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.4.4; en-us; SD4930UR Build\/KTU84P) AppleWebKit\/537.36 (KHTML, like Gecko) Silk\/3.60 like Chrome\/37.0.2026.117 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "SonyEricssonK800i\/R1AA Browser\/NetFront\/3.3 Profile\/MIDP-2.0 Configuration\/CLDC-1.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.1-update1; es-ar; SonyEricssonE15a Build\/2.0.1.A.0.47) AppleWebKit\/530.17 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/530.17",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.1-update1; pt-br; SonyEricssonU20a Build\/2.1.1.A.0.6) AppleWebKit\/530.17 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/530.17",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.3; en-au; SonyEricssonX10i Build\/3.0.1.G.0.75) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; ru-ru; SonyEricssonST18i Build\/4.0.2.A.0.62) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; hr-hr; SonyEricssonST15i Build\/4.0.2.A.0.62) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; sk-sk; SonyEricssonLT15i Build\/4.0.2.A.0.62) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.7; th-th; SonyEricssonST27i Build\/6.0.B.3.184) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.7; de-de; SonyEricssonST25i Build\/6.0.B.3.184) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; pt-br; Xperia Tablet S Build\/TID0092) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.3",
+                "Build": "TID0092",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; LT18i Build\/4.1.A.0.562) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; Sony Tablet S Build\/TISU0R0110) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; es-es; Sony Tablet S Build\/TISU0143) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-gb; SonyEricssonLT18i Build\/4.1.B.0.587) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; fr-ch; SonyEricssonSK17i Build\/4.1.B.0.587) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; SonyEricssonLT26i Build\/6.1.A.2.45) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; LT22i Build\/6.1.B.0.544) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; vi-vn; SonyEricssonLT22i Build\/6.1.B.0.544) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; ST23i Build\/11.0.A.5.5) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; ST23i Build\/11.0.A.2.10) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; LT28h Build\/6.1.E.3.7) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; SGPT13 Build\/TJDS0170) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; ja-jp; SonySO-03E Build\/10.1.E.0.265) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.2",
+                "Build": "10.1.E.0.265",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; LT26w Build\/6.2.B.1.96) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/29.0.1547.72 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; SGP321 Build\/10.3.1.A.0.33) AppleWebKit\/537.31 (KHTML, like Gecko) Chrome\/26.0.1410.58 Safari\/537.31",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.2.2",
+                "Build": "10.3.1.A.0.33",
+                "Webkit": "537.31",
+                "Chrome": "26.0.1410.58"
+            }
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; C5303 Build\/12.1.A.1.205) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/36.0.1985.135 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; zh-cn; XL39h Build\/14.2.A.1.136) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; sv-se; C5503 Build\/10.1.1.A.1.273) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; en-us; C5502 Build\/10.1.1.A.1.310) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; zh-cn; SonyL39t Build\/14.1.M.0.202) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; zh-cn; L39u Build\/14.1.n.0.63) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; zh-tw; M35c Build\/12.0.B.5.37) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; M35c Build\/12.0.B.2.42) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.90 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; zh-CN; M35t Build\/12.0.C.2.42) AppleWebKit\/534.31 (KHTML, like Gecko) UCBrowser\/9.3.2.349 U3\/0.8.0 Mobile Safari\/534.31",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; D6502 Build\/17.1.A.2.69) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/30.0.0.0 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; D6503 Build\/17.1.A.0.504) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; D6543 Build\/17.1.A.2.55) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; D2004 Build\/20.0.A.0.29) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; en-gb; D2005 Build\/20.0.A.1.12) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; D2104 Build\/20.0.B.0.84) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; D2105 Build\/20.0.B.0.74) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/33.0.1750.170 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; pt-br; D2114 Build\/20.0.B.0.85) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; D2302 Build\/18.0.B.1.23) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.138 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; zh-cn; S50h Build\/18.0.b.1.23) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 UCBrowser\/9.6.3.413 U3\/0.8.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; D2303 Build\/18.0.C.1.13) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.138 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; D2305 Build\/18.0.A.1.30) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.138 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; D2306 Build\/18.0.C.1.7) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/33.0.1750.136 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; D5303 Build\/19.0.1.A.0.207) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; D5306 Build\/19.1.A.0.264) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/33.0.1750.136 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; zh-CN; XM50h Build\/19.0.D.0.269) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 UCBrowser\/9.7.6.428 U3\/0.8.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; zh-cn; XM50t Build\/19.0.C.2.59) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; D5322 Build\/19.0.D.0.253) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.131",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; zh-cn; M51w Build\/14.2.A.1.146) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; M51w Build\/14.2.A.1.146) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/33.0.1750.136 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.1; D5102 Build\/18.2.A.0.9) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.1; D5103 Build\/18.1.A.0.11) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/30.0.1599.92 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.1; D5106 Build\/18.1.A.0.11) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; en-gb; C6902 Build\/14.2.A.1.136) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30 GSA\/3.2.17.1009776.arm",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; es-es; C6943 Build\/14.1.G.2.257) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; C6943 Build\/14.3.A.0.681) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; SGP412 Build\/14.1.B.3.320) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1; en-us; SonySGP321 Build\/10.2.C.0.143) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; SGP351 Build\/10.1.1.A.1.307) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; SGP341 Build\/10.4.B.0.569) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; SGP511 Build\/17.1.A.2.36) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.122 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; SGP512 Build\/17.1.A.2.36) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.122 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; fr-ch; SGP311 Build\/10.1.C.0.344) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; en-us; SGP312 Build\/10.1.C.0.344) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.4.2; de-de; SGP521 Build\/17.1.A.2.69) AppleWebKit\/537.16 (KHTML, like Gecko) Version\/4.0 Safari\/537.16",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.4.2; zh-cn; SGP541 Build\/17.1.A.2.36) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; SGP551 Build\/17.1.A.2.72) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "SonyEricssonU5i\/R2CA; Mozilla\/5.0 (SymbianOS\/9.4; U; Series60\/5.0 Profile\/MIDP-2.1 Configuration\/CLDC-1.1) AppleWebKit\/525 (KHTML, like Gecko) Version\/3.0 Safari\/525",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "SonyEricssonU5i\/R2AA; Mozilla\/5.0 (SymbianOS\/9.4; U; Series60\/5.0 Profile\/MIDP-2.1 Configuration\/CLDC-1.1) AppleWebKit\/525 (KHTML, like Gecko) Version\/3.0 Safari\/525",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/4.0 (PDA; PalmOS\/sony\/model prmr\/Revision:1.1.54 (en)) NetFront\/3.0",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Opera\/9.80 (Linux mips; U; InettvBrowser\/2.2 (00014A;SonyDTV115;0002;0100) KDL40EX720; CC\/BEL; en) Presto\/2.7.61 Version\/11.00",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Opera\/9.80 (Linux armv7l; HbbTV\/1.1.1 (; Sony; KDL32W650A; PKG3.211EUA; 2013;); ) Presto\/2.12.362 Version\/12.11",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; es-ve; SonyST21a2 Build\/11.0.A.6.5) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; D2533 Build\/19.2.A.0.391) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/30.0.0.0 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.4; Xperia SP Build\/KTU84Q) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/41.0.2272.96 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla \/ 5.0 (Linux; Android 5.0.2; SOT31 Build \/ 28.0.D.6.71) AppleWebKit \/ 537.36 (KHTML, like Gecko) Chrome \/ 39.0.2171.93 Safari \/ 537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 5.1.1; E5823 Build\/32.0.A.4.11) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/46.0.2490.76 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 5.0; E2303 Build\/26.1.A.3.111) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/66.0.3359.126 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; es-es; IdeaTab_A1107 Build\/MR1) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; IdeaTab A2107A-H Build\/IML74K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.90 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-au; ThinkPad Tablet Build\/ThinkPadTablet_A400_03) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "UCWEB\/2.0 (Linux; U; Opera Mini\/7.1.32052\/30.3697; en-US; IdeaTabA1000-G) U2\/1.0.0 UCBrowser\/9.2.0.419 Mobile",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; IdeaTabA1000-F Build\/JZO54K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.1; Lenovo A3000-H Build\/JOP40D) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.117 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; IdeaTab A3000-F Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Safari\/537.360",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1; zh-cn; Lenovo-A3000-H\/S100) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.1 Mobile Safari\/534.300",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; es-us; IdeaTab A3000-F Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; IdeaTab A2107A-H Build\/IML74K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; de-de; IdeaTab A2107A-H Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; es-es; IdeaTabA2109A Build\/JRO03R) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; nl-nl; IdeaTabA2109A Build\/JRO03R) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; es-es; IdeaTab_A1107 Build\/MR1) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.300",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; IdeaTab S6000-H Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.138 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-gb; IdeaTab S6000-F Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Lenovo B8000-F Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2;it-it; Lenovo B8000-F\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.2.2 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; it-it; Lenovo B6000-F\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.2.2 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Lenovo B6000-F Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; IdeaPadA10 Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/33.0.1750.166 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; Ideapad K1 Build\/JZO54K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/34.0.1847.114 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.7; de-de; IdeaPad A1 Build\/GRK393; CyanogenMod-7) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.3; Lenovo B8080-H Build\/JLS36C) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/35.0.1916.141 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; hu-hu; Lenovo A3500-FL Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; Lenovo A7600-F Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; Lenovo A5500-F Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/36.0.1985.131 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Lenovo A390 Linux\/3.0.13 Android\/4.4.2 Release\/04.03.2013 Browser\/AppleWebKit534.30 Profile\/MIDP-2.0 Configuration\/CLDC-1.1 Mobile Safari\/534.30 Android 4.0.1;",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; Lenovo TAB 2 A7-30F Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/45.0.2454.84 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; Lenovo A319 Build\/MocorDroid4.4.2) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/48.0.2564.95 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 5.1; Lenovo YT3-X90L Build\/LMY47I) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/49.0.2623.105 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0.1; Lenovo TB-X103F Build\/LenovoTB-X103F) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/56.0.2924.87 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 7.1.1; Lenovo TB-X304F Build\/NMF26F) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/60.0.3112.116 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0.1; Lenovo TB-8703F Build\/MMB29M) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/56.0.2924.87 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 7.0; Lenovo P2a42 Build\/NRD90N) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/57.0.2987.132 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 6.0.1; Lenovo P2a42 Build\/MMB29M) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/58.0.3029.83 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 7.1.1; Lenovo TB-X304L Build\/NMF26F) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/56.0.2924.87 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4.2; Tab2A7-10F Build\/KOT49H) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/30.0.0.0 Safari\/537.36 ACHEETAHI\/1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Mi",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2; xx-xx; HM NOTE 1W Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 MobilSafari\/534.30 XiaoMi\/MiuiBrowser\/1.0",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Mi",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.1; zh-cn; MI-ONE Plus Build\/ITL41D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30 XiaoMi\/MiuiBrowser\/1.0",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Mi",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; zh-cn; MI 2SC Build\/JRO03L) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30 XiaoMi\/MiuiBrowser\/1.0",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Mi",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; zh-cn; MI 2S Build\/JRO03L) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30 XiaoMi\/MiuiBrowser\/1.0",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Mi",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; zh-tw; MI 1S Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30 XiaoMi\/MiuiBrowser\/1.0",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Mi",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.8; zh-cn; xiaomi2 Build\/GRK39F) AppleWebKit\/533.1 (KHTML, like Gecko)Version\/4.0 MQQBrowser\/4.4 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Mi",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; es-es; MI 2A Build\/miui.es JRO03L) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30 XiaoMi\/MiuiBrowser\/1.0",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Mi",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.1; zh-cn; MI 3 Build\/JOP40D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30 XiaoMi\/MiuiBrowser\/1.0",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Mi",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; en-us; MI 1S Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30 XiaoMi\/MiuiBrowser\/1.0",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Mi",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; zh-cn; MI 3W Build\/JLS36C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30 XiaoMi\/MiuiBrowser\/1.0",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Mi",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; zh-cn; HM 1SC Build\/JLS36C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30 XiaoMi\/MiuiBrowser\/1.0",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Mi",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.3; en-us; HM 1SW Build\/JLS36C) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/537.36 XiaoMi\/MiuiBrowser\/2.0.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Mi",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; HM NOTE 1W Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/537.36 XiaoMi\/MiuiBrowser\/2.0.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Mi",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; en-us; MI-ONE C1 Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30 XiaoMi\/MiuiBrowser\/1.0",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Mi",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.4.4; en-us; MI 4W Build\/KTU84P) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/537.36 XiaoMi\/MiuiBrowser\/2.0.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Mi",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.4; MI PAD Build\/KTU84P) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/33.0.0.0 Safari\/537.36",
             "mobile": true,
             "tablet": true
         }


### PR DESCRIPTION
Fixed Google Pixel 2 - Android 8.1.0 (July 2018 - OPM2.171026.006.G1) detected as Galapad tablet fixed. UA: Mozilla/5.0 (Linux; Android 8.1.0; Pixel 2 Build/OPM2.171026.006.G1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36