### PR TITLE
PHP 8 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,9 @@ language: php
 
 matrix:
   include:
-    - php: 5.3
-      dist: precise
-    - php: 5.4
-    - php: 5.5
-    - php: 5.6
-    - php: 7.0
-    - php: 7.1
     - php: 7.2
+    - php: 7.3
+    - php: 7.4
     - php: nightly
   allow_failures:
     - php: nightly

--- a/Mobile_Detect.php
+++ b/Mobile_Detect.php
@@ -1053,7 +1053,7 @@ class Mobile_Detect
 
         foreach ($this->getMobileHeaders() as $mobileHeader => $matchType) {
             if (isset($this->httpHeaders[$mobileHeader])) {
-                if (is_array($matchType['matches'])) {
+                if (isset($matchType['matches']) && is_array($matchType['matches'])) {
                     foreach ($matchType['matches'] as $_match) {
                         if (strpos($this->httpHeaders[$mobileHeader], $_match) !== false) {
                             return true;

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
         }
     ],
     "require": {
-        "php": ">=5.0.0"
+        "php": "^7.2 || ^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8.35||~5.7"
+        "phpunit/phpunit": "~8.0 || ^9.4"
     },
     "autoload": {
         "classmap": ["Mobile_Detect.php"],

--- a/tests/BasicsTest.php
+++ b/tests/BasicsTest.php
@@ -18,7 +18,7 @@ class BasicTest extends TestCase
         $this->assertTrue(class_exists('Mobile_Detect'));
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->detect = new Mobile_Detect;
     }
@@ -241,39 +241,6 @@ class BasicTest extends TestCase
         $this->assertEquals(strlen($md->getUserAgent()), 500);
     }
 
-    public function testSetDetectionType()
-    {
-        $md = new Mobile_Detect(array());
-
-        $md->setDetectionType('bskdfjhs');
-        $this->assertAttributeEquals(
-            Mobile_Detect::DETECTION_TYPE_MOBILE,
-            'detectionType',
-            $md
-        );
-
-        $md->setDetectionType();
-        $this->assertAttributeEquals(
-            Mobile_Detect::DETECTION_TYPE_MOBILE,
-            'detectionType',
-            $md
-        );
-
-        $md->setDetectionType(Mobile_Detect::DETECTION_TYPE_MOBILE);
-        $this->assertAttributeEquals(
-            Mobile_Detect::DETECTION_TYPE_MOBILE,
-            'detectionType',
-            $md
-        );
-
-        $md->setDetectionType(Mobile_Detect::DETECTION_TYPE_EXTENDED);
-        $this->assertAttributeEquals(
-            Mobile_Detect::DETECTION_TYPE_EXTENDED,
-            'detectionType',
-            $md
-        );
-    }
-
     //special headers that give 'quick' indication that a device is mobile
     public function quickHeadersData()
     {
@@ -376,11 +343,9 @@ class BasicTest extends TestCase
         $this->assertFalse($md->checkHttpHeadersForMobile());
     }
 
-    /**
-     * @expectedException BadMethodCallException
-     */
     public function testBadMethodCall()
     {
+        $this->expectException(BadMethodCallException::class);
         $md = new Mobile_Detect(array());
         $md->badmethodthatdoesntexistatall();
     }

--- a/tests/UserAgentTest.php
+++ b/tests/UserAgentTest.php
@@ -12,7 +12,7 @@ class UserAgentTest extends TestCase
     protected static $ualist = array();
     protected static $json;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->detect = new Mobile_Detect;
     }
@@ -115,7 +115,7 @@ class UserAgentTest extends TestCase
         return self::$json;
     }
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         //generate json file first
         self::generateJson();

--- a/tests/VendorsTest_tmp.php
+++ b/tests/VendorsTest_tmp.php
@@ -11,13 +11,13 @@ class VendorsTest extends TestCase
     protected $detect;
     protected static $items;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->detect = new Mobile_Detect;
 
     }
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         //this method could be called multiple times
         if (!self::$items) {


### PR DESCRIPTION
Hey,

I took the liberty to propose a minimal changeset for php 8 support and with that also drop support for unsupported php versions (https://www.php.net/supported-versions.php).

- dropped support for php versions older than 7.2
- updated phpunit version
- compatibility fixes