### PR TITLE
Fix deprecation error in PHP 8.1

### DIFF
--- a/Mobile_Detect.php
+++ b/Mobile_Detect.php
@@ -1455,7 +1455,7 @@ class Mobile_Detect
      *
      * @todo: search in the HTTP headers too.
      */
-    public function match($regex, $userAgent = null)
+    public function match($regex, $userAgent = '')
     {
         $match = (bool) preg_match(sprintf('#%s#is', $regex), (false === empty($userAgent) ? $userAgent : $this->userAgent), $matches);
         // If positive match is found, store the results for debug.

--- a/Mobile_Detect.php
+++ b/Mobile_Detect.php
@@ -1455,8 +1455,12 @@ class Mobile_Detect
      *
      * @todo: search in the HTTP headers too.
      */
-    public function match($regex, $userAgent = '')
+    public function match($regex, $userAgent = null)
     {
+        if(!$userAgent){
+            return false;
+        }
+        
         $match = (bool) preg_match(sprintf('#%s#is', $regex), (false === empty($userAgent) ? $userAgent : $this->userAgent), $matches);
         // If positive match is found, store the results for debug.
         if ($match) {


### PR DESCRIPTION
Fix errors in php8.1 : preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in