### PR TITLE
Fix: Chrome, Firefox, Edge on iOS - wrong detection in desktop mode

### DIFF
--- a/Mobile_Detect.php
+++ b/Mobile_Detect.php
@@ -720,14 +720,14 @@ class Mobile_Detect
     protected static $browsers = array(
         //'Vivaldi'         => 'Vivaldi',
         // @reference: https://developers.google.com/chrome/mobile/docs/user-agent
-        'Chrome'          => '\bCrMo\b|CriOS|Android.*Chrome/[.0-9]* (Mobile)?',
+        'Chrome'          => '\bCrMo\b|CriOS.*Mobile|Android.*Chrome/[.0-9]* Mobile',
         'Dolfin'          => '\bDolfin\b',
         'Opera'           => 'Opera.*Mini|Opera.*Mobi|Android.*Opera|Mobile.*OPR/[0-9.]+$|Coast/[0-9.]+',
         'Skyfire'         => 'Skyfire',
         // Added "Edge on iOS" https://github.com/serbanghita/Mobile-Detect/issues/764
-        'Edge'             => '\bEdgiOS\b|Mobile Safari/[.0-9]* Edge',
+        'Edge'             => 'EdgiOS.*Mobile|Mobile Safari/[.0-9]* Edge',
         'IE'              => 'IEMobile|MSIEMobile', // |Trident/[.0-9]+
-        'Firefox'         => 'fennec|firefox.*maemo|(Mobile|Tablet).*Firefox|Firefox.*Mobile|FxiOS',
+        'Firefox'         => 'fennec|firefox.*maemo|(Mobile|Tablet).*Firefox|Firefox.*Mobile|FxiOS.*Mobile',
         'Bolt'            => 'bolt',
         'TeaShark'        => 'teashark',
         'Blazer'          => 'Blazer',


### PR DESCRIPTION
Complete fix for Issue https://github.com/serbanghita/Mobile-Detect/issues/857 (see comments of the issue)