### PR TITLE
Fix: Method annotations are in the wrong place

### DIFF
--- a/scripts/dump_magic_methods.php
+++ b/scripts/dump_magic_methods.php
@@ -9,7 +9,7 @@ $detect = new MobileDetect();
 /**
  * Dump all methods (+ extended)
  * Use this script to generate comments like "@method bool isiPhone()"
- * php export/dump_magic_methods.php > methods.txt
+ * php scripts/dump_magic_methods.php > methods.txt
  */
 foreach ($detect->getRules() as $name => $regex) {
     echo "is$name()\n";

--- a/scripts/dump_magic_methods.php
+++ b/scripts/dump_magic_methods.php
@@ -2,12 +2,14 @@
 
 use Detection\MobileDetect;
 
-$detect = new MobileDetect;
+require_once __DIR__ . '/../src/MobileDetect.php';
+
+$detect = new MobileDetect();
 
 /**
  * Dump all methods (+ extended)
  * Use this script to generate comments like "@method bool isiPhone()"
- * php -a examples/dump_magic_methods.php > methods.txt
+ * php export/dump_magic_methods.php > methods.txt
  */
 foreach ($detect->getRules() as $name => $regex) {
     echo "is$name()\n";

--- a/src/MobileDetect.php
+++ b/src/MobileDetect.php
@@ -26,7 +26,7 @@ use BadMethodCallException;
 
 /**
  * Auto-generated isXXXX() magic methods.
- * php export/dump_magic_methods.php
+ * php scripts/dump_magic_methods.php
  *
  * @method bool isiPhone()
  * @method bool isBlackBerry()

--- a/src/MobileDetect.php
+++ b/src/MobileDetect.php
@@ -19,9 +19,14 @@
  * @author: Victor Stanciu <vic.stanciu@gmail.com> (original author)
  *
  * @version 3.74.0
- *
+ */
+namespace Detection;
+
+use BadMethodCallException;
+
+/**
  * Auto-generated isXXXX() magic methods.
- * php -a export/dump_magic_methods.php
+ * php export/dump_magic_methods.php
  *
  * @method bool isiPhone()
  * @method bool isBlackBerry()
@@ -212,12 +217,7 @@
  * @method bool isWebKit()
  * @method bool isConsole()
  * @method bool isWatch()
-
  */
-namespace Detection;
-
-use BadMethodCallException;
-
 class MobileDetect
 {
     /**

--- a/src/MobileDetect.php
+++ b/src/MobileDetect.php
@@ -944,7 +944,7 @@ class MobileDetect
      *
      * @param array|null $cfHeaders List of HTTP headers
      *
-     * @return  boolean If there were CloudFront headers to be set
+     * @return bool If there were CloudFront headers to be set
      */
     public function setCfHeaders(array $cfHeaders = null): bool
     {
@@ -1168,8 +1168,8 @@ class MobileDetect
     /**
      * Find a detection rule that matches the current User-agent.
      *
-     * @param  null    $userAgent deprecated
-     * @return boolean
+     * @param  string|null $userAgent deprecated
+     * @return bool
      */
     protected function matchDetectionRulesAgainstUA($userAgent = null): bool
     {
@@ -1194,7 +1194,7 @@ class MobileDetect
      *
      * @param string $key
      *
-     * @return boolean
+     * @return bool
      */
     protected function matchUAAgainstKey(string $key): bool
     {
@@ -1219,8 +1219,8 @@ class MobileDetect
     /**
      * Check if the device is mobile.
      * Returns true if any type of mobile device detected, including special ones
-     * @param  null $userAgent   deprecated
-     * @param  null $httpHeaders deprecated
+     * @param  string|null $userAgent  deprecated
+     * @param  array|null $httpHeaders deprecated
      * @return bool
      */
     public function isMobile($userAgent = null, $httpHeaders = null): bool
@@ -1287,8 +1287,8 @@ class MobileDetect
      * @param string|null $userAgent   deprecated
      * @param array|null $httpHeaders deprecated
      * @return bool
-     *@todo: The httpHeaders part is not yet used.
      *
+     * @todo: The httpHeaders part is not yet used.
      */
     public function is(string $key, string $userAgent = null, array $httpHeaders = null): bool
     {
@@ -1313,7 +1313,7 @@ class MobileDetect
      * This method will be used to check custom regexes against
      * the User-Agent string.
      *
-     * @param $regex
+     * @param string $regex
      * @param string|null $userAgent
      * @return bool
      *
@@ -1355,8 +1355,8 @@ class MobileDetect
      * @param string $ver The string version, like "2.6.21.2152";
      *
      * @return float
-          *@todo Remove the error suppression from str_replace() call.
      *
+     * @todo Remove the error suppression from str_replace() call.
      */
     public function prepareVersionNo(string $ver): float
     {


### PR DESCRIPTION
The method annotations must be above the class definition and not above the namespace.