### PR TITLE
Update composer to use correct autoload setting for tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,11 @@
             "src/MobileDetect.php"
         ],
         "psr-4": {
-            "Detection\\": "src/",
+            "Detection\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "DetectionTests\\": "tests/"
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         {
             "name": "Serban Ghita",
             "email": "serbanghita@gmail.com",
-            "homepage": "http://mobiledetect.net",
+            "homepage": "https://mobiledetect.net",
             "role": "Developer"
         }
     ],


### PR DESCRIPTION
This PR updates the `composer.json` file to move the `autoload` setting for `tests/` into `autoload-dev`.

The reason for this change is that the `tests/` directory is (correctly) not inculded in distribution, but including it in the normal `autoload` property still specifies the testing namespace. In distribution, this namespace doesn't exist.

More specifically, if we attempt to use a 3rd party tool (such as [Mozart](https://github.com/coenjacobs/mozart)) to add a prefix to this namespace, the extraneous namespace for `tests/` causes an error to be thrown. Moving the namespace to `autoload-dev` solves this issue.

