### PR TITLE
Declare support for older psr/simple-cache version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=8.0",
-        "psr/simple-cache": "^3.0"
+        "psr/simple-cache": "^1 || ^2 || ^3"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^v3.35.1",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=8.0",
-        "psr/simple-cache": "^1 || ^2 || ^3"
+        "psr/simple-cache": "^2 || ^3"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^v3.35.1",


### PR DESCRIPTION
the only changes between psr/simple-cache [v2](https://github.com/php-fig/simple-cache/releases/tag/2.0.0) and [v3](https://github.com/php-fig/simple-cache/releases/tag/3.0.0) is added return types - which is a backwards compatible change.

from the mobile detect point of view these 2 should work. would be great if we could leave the decision which exactly is used to "composer install" to be compatible with more packages out there.


verified by running the test-suite locally with psr/simple-cache:v2