### PR TITLE
PHP 8.4 - implicit nulls are deprecated

### DIFF
--- a/.github/workflows/4.8.x-test.yml
+++ b/.github/workflows/4.8.x-test.yml
@@ -4,14 +4,14 @@ name: 4.8.x on PHP 8.x
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-  
+
   push:
     branches: ['4.8.x']
     paths-ignore:
       - '*.md'
       - '.github/**'
       - 'scripts/**'
-      
+
   pull_request:
     branches: ['4.8.x']
     paths-ignore:
@@ -24,12 +24,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        php-version: [8.0, 8.1, 8.2, 8.3]
+        php-version: [8.0, 8.1, 8.2, 8.3, 8.4]
         os: ['ubuntu-latest']
-        include:
-          - os: 'ubuntu-latest'
-            phpunit-version: '9.6.10'
-            composer-version: 'latest'
+        composer-version: ['latest']
+        phpunit-version: ['^9.6.18']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^v3.35.1",
-        "phpunit/phpunit": "^9.6",
+        "phpunit/phpunit": "^9.6.18",
         "squizlabs/php_codesniffer": "^3.7",
         "phpbench/phpbench": "^1.2",
-        "phpstan/phpstan": "^1.10"
+        "phpstan/phpstan": "^1.12.x-dev"
     },
     "autoload": {
         "psr-4": {

--- a/src/Cache/CacheException.php
+++ b/src/Cache/CacheException.php
@@ -6,7 +6,7 @@ use Psr\SimpleCache\InvalidArgumentException;
 
 class CacheException extends \Exception
 {
-    public function __construct($message, $code = 0, \Throwable $previous = null)
+    public function __construct($message, $code = 0, ?\Throwable $previous = null)
     {
         // some code
 

--- a/src/MobileDetect.php
+++ b/src/MobileDetect.php
@@ -1028,11 +1028,11 @@ class MobileDetect
      * Construct an instance of this class.
      */
     public function __construct(
-        Cache $cache = null,
+        ?Cache $cache = null,
         array $config = [],
     ) {
         // If no custom cache provided then use our own.
-        $this->cache = $cache == null ? new Cache() : $cache;
+        $this->cache = $cache ?? new Cache();
         // Override config from user.
         $this->config = array_merge($this->config, $config);
 


### PR DESCRIPTION
Use explicit nullable type.

`MobileDetect::__construct(): Implicitly marking parameter $cache as nullable is deprecated, the explicit nullable type must be used instead`

`CacheException::__construct(): Implicitly marking parameter $previous as nullable is deprecated, the explicit nullable type must be used instead`

Also updated Github Actions workflow to include PHP 8.4

Fixes #956
Replaces #957