### PR TITLE
Use Client Hints Sec-CH-UA-Mobile header to detect mobile

### DIFF
--- a/src/MobileDetect.php
+++ b/src/MobileDetect.php
@@ -333,6 +333,8 @@ class MobileDetect
         'HTTP_X_ATT_DEVICEID'          => null,
         // Seen this on a HTC.
         'HTTP_UA_CPU'                  => ['matches' => ['ARM']],
+        // See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-CH-UA-Mobile
+        'Sec-CH-UA-Mobile'             => ['matches' => ['?1']],
     ];
 
     /**

--- a/tests/MobileDetectGeneralTest.php
+++ b/tests/MobileDetectGeneralTest.php
@@ -394,7 +394,10 @@ final class MobileDetectGeneralTest extends TestCase
             ]],
             [[
                 'HTTP_UA_CPU' => 'ARM'
-            ]]
+            ]],
+            [[
+                'Sec-CH-UA-Mobile' => '?1'
+            ]],
         ];
     }
 
@@ -428,6 +431,9 @@ final class MobileDetectGeneralTest extends TestCase
             ]],
             [[
                 'HTTP_VIA' => '1.1 ws-proxy.stuff.co.il C0A800FA'
+            ]],
+            [[
+                'Sec-CH-UA-Mobile' => '?0'
             ]],
         ];
     }


### PR DESCRIPTION
Chrome now sends Client Hint headers and a frozen UA string in newer versions. See this post for a full explanation: 
https://developer.chrome.com/docs/privacy-security/user-agent-client-hints

`Sec-CH-UA-Mobile` specifically is a "low-entropy hint" which means it is sent with every request. See: 
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-CH-UA-Platform

This partially resolves the issue in #906 although I didn't do anything with tablet detection.