### PR TITLE
Add missing `psr/cache`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": ">=8.0",
+        "psr/cache": "^2 || ^3",
         "psr/simple-cache": "^2 || ^3"
     },
     "require-dev": {


### PR DESCRIPTION
Fixed "Interface "Psr\Cache\CacheItemInterface" not found" error after upgrading to `4.8.07`

See laravel/jetstream#1552