### PR TITLE
phpstan - return to production ver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "phpunit/phpunit": "^9.6.18",
         "squizlabs/php_codesniffer": "^3.11.1",
         "phpbench/phpbench": "^1.2",
-        "phpstan/phpstan": "^1.12.x-dev"
+        "phpstan/phpstan": "^1.12"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The `...-x-dev` version was only used temporarily during an older PR 960 to get tests to pass.

This PR simply resets it to normal.

Described at: https://github.com/serbanghita/Mobile-Detect/pull/960#issuecomment-2273958313

Note: phpstan is only used by the tests, and is not required for Mobile-Detect to work.