### PR TITLE
Make VERSION_TYPE_* consts public

### DIFF
--- a/src/MobileDetect.php
+++ b/src/MobileDetect.php
@@ -269,12 +269,12 @@ class MobileDetect
     /**
      * A type for the version() method indicating a string return value.
      */
-    private const VERSION_TYPE_STRING = 'text';
+    public const VERSION_TYPE_STRING = 'text';
 
     /**
      * A type for the version() method indicating a float return value.
      */
-    private const VERSION_TYPE_FLOAT = 'float';
+    public const VERSION_TYPE_FLOAT = 'float';
 
     /**
      * The User-Agent HTTP header is stored in here.


### PR DESCRIPTION
The constants are part of the public API contract, i.e. `->version($osName, Agent::VERSION_TYPE_FLOAT)` so they should not be private visibility.