### PR TITLE
feat(lsb): consistent late static binding for subclass extensibility

### DIFF
--- a/src/MobileDetect.php
+++ b/src/MobileDetect.php
@@ -1086,9 +1086,9 @@ class MobileDetect
         // Go through known HTTP headers that we care about.
         // See "4.1.18. Protocol-Specific Meta-Variables" of http://www.faqs.org/rfcs/rfc3875.html
         $knownHttpHeaders = array_merge(
-            array_values(self::$knownUserAgentHttpHeaders),
-            array_keys(self::$knownMobilePositiveHeaders),
-            array_values(self::$knownCloudFrontHeaders)
+            array_values(static::$knownUserAgentHttpHeaders),
+            array_keys(static::$knownMobilePositiveHeaders),
+            array_values(static::$knownCloudFrontHeaders)
         );
 
         // Did not iterate through global $_SERVER to find ['HTTP...'] header values
@@ -1141,10 +1141,10 @@ class MobileDetect
 
         // Override User-Agent string if 'Amazon Cloudfront' specific HTTP headers are present.
         if (
-            $this->hasHttpHeader(self::$knownCloudFrontHeaders[0]) ||
-            $this->hasHttpHeader(self::$knownCloudFrontHeaders[1])
+            $this->hasHttpHeader(static::$knownCloudFrontHeaders[0]) ||
+            $this->hasHttpHeader(static::$knownCloudFrontHeaders[1])
         ) {
-            $this->setUserAgent(self::$cloudFrontUA);
+            $this->setUserAgent(static::$cloudFrontUA);
         }
     }
 
@@ -1319,10 +1319,10 @@ class MobileDetect
      */
     public function getRules(): array
     {
-        static $rules;
-
-        if (!$rules) {
-            $rules = array_merge(
+        static $rulesByClass = [];
+        $class = static::class;
+        if (!isset($rulesByClass[$class])) {
+            $rulesByClass[$class] = array_merge(
                 static::$browsers,
                 static::$operatingSystems,
                 static::$phoneDevices,
@@ -1330,7 +1330,7 @@ class MobileDetect
             );
         }
 
-        return $rules;
+        return $rulesByClass[$class];
     }
 
     /**
@@ -1418,7 +1418,7 @@ class MobileDetect
 
             // Special case: Amazon CloudFront mobile viewer
             if (
-                $this->getUserAgent() === self::$cloudFrontUA &&
+                $this->getUserAgent() === static::$cloudFrontUA &&
                 $this->getHttpHeader('HTTP_CLOUDFRONT_IS_MOBILE_VIEWER') === 'true'
             ) {
                 $this->cache->set($cacheKey, true, $this->config['cacheTtl']);
@@ -1464,7 +1464,7 @@ class MobileDetect
 
             // Special case: Amazon CloudFront mobile viewer
             if (
-                $this->getUserAgent() === self::$cloudFrontUA &&
+                $this->getUserAgent() === static::$cloudFrontUA &&
                 $this->getHttpHeader('HTTP_CLOUDFRONT_IS_TABLET_VIEWER') === 'true'
             ) {
                 $this->cache->set($cacheKey, true, $this->config['cacheTtl']);
@@ -1678,7 +1678,7 @@ class MobileDetect
             $type = self::VERSION_TYPE_STRING;
         }
 
-        $properties = self::getProperties();
+        $properties = static::getProperties();
 
         // Check if the property exists in the properties array.
         if (true === isset($properties[$propertyName])) {
@@ -1687,7 +1687,7 @@ class MobileDetect
             $properties[$propertyName] = (array) $properties[$propertyName];
 
             foreach ($properties[$propertyName] as $propertyMatchString) {
-                $propertyPattern = str_replace('[VER]', self::VERSION_REGEX, $propertyMatchString);
+                $propertyPattern = str_replace('[VER]', static::VERSION_REGEX, $propertyMatchString);
 
                 // Identify and extract the version.
                 preg_match(sprintf('#%s#is', $propertyPattern), $this->userAgent, $match);

--- a/tests/Fixtures/CustomMobileDetect.php
+++ b/tests/Fixtures/CustomMobileDetect.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace DetectionTests\Fixtures;
+
+use Detection\MobileDetect;
+
+/**
+ * A subclass that adds custom detection rules to verify LSB (late static binding) works.
+ */
+class CustomMobileDetect extends MobileDetect
+{
+    protected static array $phoneDevices = [
+        'CustomPhone' => 'CustomPhone[/]',
+    ];
+
+    protected static array $tabletDevices = [
+        'CustomTablet' => 'CustomTablet[/]',
+    ];
+
+    protected static array $properties = [
+        'CustomPhone' => 'CustomPhone/[VER]',
+        'CustomTablet' => 'CustomTablet/[VER]',
+    ];
+}

--- a/tests/MobileDetectSubclassTest.php
+++ b/tests/MobileDetectSubclassTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace DetectionTests;
+
+use Detection\Exception\MobileDetectException;
+use DetectionTests\Fixtures\CustomMobileDetect;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests that MobileDetect supports subclassing via late static binding.
+ * Subclasses can override static property arrays to provide custom detection rules.
+ */
+final class MobileDetectSubclassTest extends TestCase
+{
+    public function testGetPhoneDevicesReturnsSubclassRules(): void
+    {
+        $devices = CustomMobileDetect::getPhoneDevices();
+        $this->assertArrayHasKey('CustomPhone', $devices);
+        $this->assertArrayNotHasKey('iPhone', $devices);
+    }
+
+    public function testGetTabletDevicesReturnsSubclassRules(): void
+    {
+        $devices = CustomMobileDetect::getTabletDevices();
+        $this->assertArrayHasKey('CustomTablet', $devices);
+        $this->assertArrayNotHasKey('iPad', $devices);
+    }
+
+    public function testGetPropertiesReturnsSubclassProperties(): void
+    {
+        $properties = CustomMobileDetect::getProperties();
+        $this->assertArrayHasKey('CustomPhone', $properties);
+        $this->assertArrayNotHasKey('iPhone', $properties);
+    }
+
+    public function testGetRulesIncludesSubclassRules(): void
+    {
+        $detect = new CustomMobileDetect(null, ['autoInitOfHttpHeaders' => false]);
+        $rules = $detect->getRules();
+        $this->assertArrayHasKey('CustomPhone', $rules);
+        $this->assertArrayHasKey('CustomTablet', $rules);
+    }
+
+    /**
+     * @throws MobileDetectException
+     */
+    public function testIsMobileRecognizesCustomPhoneRule(): void
+    {
+        $detect = new CustomMobileDetect(null, ['autoInitOfHttpHeaders' => false]);
+        $detect->setUserAgent('CustomPhone/2.1.0');
+        $this->assertTrue($detect->isMobile());
+    }
+
+    /**
+     * @throws MobileDetectException
+     */
+    public function testIsTabletRecognizesCustomTabletRule(): void
+    {
+        $detect = new CustomMobileDetect(null, ['autoInitOfHttpHeaders' => false]);
+        $detect->setUserAgent('CustomTablet/1.0');
+        $this->assertTrue($detect->isTablet());
+    }
+
+    /**
+     * @throws MobileDetectException
+     */
+    public function testVersionExtractsFromCustomProperties(): void
+    {
+        $detect = new CustomMobileDetect(null, ['autoInitOfHttpHeaders' => false]);
+        $detect->setUserAgent('CustomPhone/2.1.0');
+        $this->assertSame('2.1.0', $detect->version('CustomPhone'));
+        $this->assertSame(2.1, $detect->version('CustomPhone', 'float'));
+    }
+
+    /**
+     * @throws MobileDetectException
+     */
+    public function testParentRulesDoNotLeakIntoSubclass(): void
+    {
+        $detect = new CustomMobileDetect(null, ['autoInitOfHttpHeaders' => false]);
+        $detect->setUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X)');
+        $this->assertFalse($detect->isMobile());
+    }
+}

--- a/tests/MobileDetectSubclassTest.php
+++ b/tests/MobileDetectSubclassTest.php
@@ -3,6 +3,7 @@
 namespace DetectionTests;
 
 use Detection\Exception\MobileDetectException;
+use Detection\MobileDetect;
 use DetectionTests\Fixtures\CustomMobileDetect;
 use PHPUnit\Framework\TestCase;
 
@@ -77,6 +78,13 @@ final class MobileDetectSubclassTest extends TestCase
      */
     public function testParentRulesDoNotLeakIntoSubclass(): void
     {
+        // Prime the parent class getRules() cache first — without the class-keyed
+        // cache fix, the parent's 186 rules would leak into the subclass and this
+        // iPhone UA would incorrectly match.
+        $parent = new MobileDetect(null, ['autoInitOfHttpHeaders' => false]);
+        $parent->setUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X)');
+        $this->assertTrue($parent->isMobile());
+
         $detect = new CustomMobileDetect(null, ['autoInitOfHttpHeaders' => false]);
         $detect->setUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X)');
         $this->assertFalse($detect->isMobile());


### PR DESCRIPTION
## Summary

- Replace all remaining `self::` references to static properties and overridable constants with `static::` so subclasses can reliably override detection rules, version patterns, and CloudFront headers
- Fix `getRules()` function-level static cache that was shared across the class hierarchy — subclass instances would silently get the parent's cached rules. Now uses a class-keyed cache via `static::class`
- Add subclass extensibility tests (`MobileDetectSubclassTest`) that validate the LSB contract end-to-end

Addresses #998 — the original PR changed only `self::getProperties()` → `static::getProperties()` in `version()`, but the inconsistency was wider (8 static property refs + 1 protected constant).

### Changes in `src/MobileDetect.php`

| Location | Change |
|----------|--------|
| `autoInitKnownHttpHeaders()` | `self::$knownUserAgentHttpHeaders`, `$knownMobilePositiveHeaders`, `$knownCloudFrontHeaders` → `static::` |
| `setHttpHeaders()` | `self::$knownCloudFrontHeaders[0]`, `[1]`, `$cloudFrontUA` → `static::` |
| `isMobile()` | `self::$cloudFrontUA` → `static::` |
| `isTablet()` | `self::$cloudFrontUA` → `static::` |
| `version()` | `self::getProperties()` → `static::getProperties()` |
| `version()` | `self::VERSION_REGEX` → `static::VERSION_REGEX` (protected const) |
| `getRules()` | `static $rules` → `static $rulesByClass[static::class]` (class-keyed cache) |

### What stays as `self::`

Private constants `VERSION_TYPE_STRING` and `VERSION_TYPE_FLOAT` — they cannot be overridden by subclasses, so `self::` is correct. The default parameter `string $type = self::VERSION_TYPE_STRING` must also use `self::` (PHP requires compile-time constants in signatures).

### Benchmark results (phpbench, 10 iterations × 1000 revs, retry-threshold=1)

| Benchmark | Baseline (ops/s) | After (ops/s) | Delta |
|-----------|-------------------|---------------|-------|
| `benchIsMobileAgainstBestMatch` | 78,144 | 77,550 | +0.77% |
| `benchIsMobileAgainstWorstMatch` | 10,751 | 10,797 | -0.43% |
| `benchIsTabletAgainstBestMatch` | 256,664 | 260,486 | -1.47% |
| `benchIsTabletAgainstWorstMatch` | 21,396 | 21,757 | -1.66% |
| `benchIsIOS` | 106,007 | 106,832 | -0.77% |
| `benchIsIpad` | 107,190 | 107,151 | +0.04% |
| `benchIsSamsung` | 63,223 | 63,436 | -0.34% |
| `benchIsSamsungTablet` | 82,539 | 83,271 | -0.88% |

All within noise (±2% assertion threshold). Zero performance regression, memory unchanged at 1.792mb.

## Test plan

- [x] Full test suite: 1872 tests, 4319 assertions pass
- [x] PHPStan level 3: no errors
- [x] PHPCS (PSR-12): no errors
- [x] New `MobileDetectSubclassTest`: 8 tests validating subclass can override phone/tablet rules, properties, and version extraction
- [x] Benchmark comparison against baseline: all assertions pass